### PR TITLE
added event driven parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ Boon is 90,000 lines of code (just Java main not including test classes).
 Boon does too many things that no one uses. It was due for a complete redesign. 
 It also uses Unsafe which you can't do in later version of Java. 
 
-JParse is feature complete now done and is only 4,570 lines long vs. 90,000 LoC of Boon. 
+JParse is feature complete now done and is only 5,098 lines long vs. 90,000 LoC of Boon. 
 Jackson core is 55,000 LOC and there are other libs needed for various data types and mappings if you use Jackson. 
 
 
 ## What is JParse?
 
 JParse is a *JSON parser* plus a small subset of *JSONPath*.
-It is small (just 4,200 lines long). It uses an index overlay from the ground up which lays the foundation for quick JSONPath lookups 
+It is small (just 5,098 lines long). It uses an index overlay from the ground up which lays the foundation for quick JSONPath lookups 
 as well as very fast mapping. It will not grow in feature set. Any other features will be part of other libs. 
 
 

--- a/src/main/java/com/cloudurable/jparse/Json.java
+++ b/src/main/java/com/cloudurable/jparse/Json.java
@@ -4,6 +4,7 @@ import com.cloudurable.jparse.node.ArrayNode;
 import com.cloudurable.jparse.node.Node;
 import com.cloudurable.jparse.node.ObjectNode;
 import com.cloudurable.jparse.node.RootNode;
+import com.cloudurable.jparse.parser.JsonParser;
 import com.cloudurable.jparse.source.CharSource;
 import com.cloudurable.jparse.token.Token;
 

--- a/src/main/java/com/cloudurable/jparse/Path.java
+++ b/src/main/java/com/cloudurable/jparse/Path.java
@@ -1,47 +1,16 @@
 package com.cloudurable.jparse;
 
-import com.cloudurable.jparse.node.*;
+import com.cloudurable.jparse.node.ArrayNode;
+import com.cloudurable.jparse.node.Node;
+import com.cloudurable.jparse.node.ObjectNode;
 import com.cloudurable.jparse.path.PathElement;
 import com.cloudurable.jparse.path.PathNode;
 import com.cloudurable.jparse.path.PathParser;
 import com.cloudurable.jparse.source.support.PathException;
-import com.cloudurable.jparse.source.support.UnexpectedCharacterException;
 
 import java.util.Iterator;
 
 public class Path {
-
-    public static int intAtPath(final String path, final Node rootNode) {
-        return numberNodeAtPath(path, rootNode).intValue();
-    }
-
-    public static float floatAtPath(final String path, final Node rootNode) {
-        return numberNodeAtPath(path, rootNode).floatValue();
-    }
-
-    public static double doubleAtPath(final String path, final Node rootNode) {
-        return numberNodeAtPath(path, rootNode).doubleValue();
-    }
-
-    public static long longAtPath(final String path, final Node rootNode) {
-        return numberNodeAtPath(path, rootNode).longValue();
-    }
-
-    public static CharSequence charSequenceAtPath(final String path, final Node rootNode) {
-        return stringNodeAtPath(path, rootNode).charSequence();
-    }
-
-    public static CharSequence stringAtPath(final String path, final Node rootNode) {
-        return stringNodeAtPath(path, rootNode).toString();
-    }
-
-    private static NumberNode numberNodeAtPath(String path, Node rootNode) {
-        return (NumberNode) atPath(path, rootNode);
-    }
-
-    private static StringNode stringNodeAtPath(String path, Node rootNode) {
-        return (StringNode) atPath(path, rootNode);
-    }
 
     public static Node atPath(final String path, final String json) {
         return atPath(path, Json.toRootNode(json));

--- a/src/main/java/com/cloudurable/jparse/node/RootNode.java
+++ b/src/main/java/com/cloudurable/jparse/node/RootNode.java
@@ -6,12 +6,14 @@ import com.cloudurable.jparse.node.support.TokenSubList;
 import com.cloudurable.jparse.path.PathNode;
 import com.cloudurable.jparse.source.CharSource;
 import com.cloudurable.jparse.token.Token;
-import static com.cloudurable.jparse.token.TokenTypes.*;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+
+import static com.cloudurable.jparse.token.TokenTypes.ARRAY_TOKEN;
+import static com.cloudurable.jparse.token.TokenTypes.OBJECT_TOKEN;
 
 
 public class RootNode implements CollectionNode {
@@ -76,6 +78,16 @@ public class RootNode implements CollectionNode {
 
     public ObjectNode getObjectNode() {
         return (ObjectNode) getNode();
+    }
+
+    @Override
+    public ArrayNode asArray() {
+        return getArrayNode();
+    }
+
+    @Override
+    public ObjectNode asObject() {
+        return getObjectNode();
     }
 
     public Map<String, Object> getMap() {

--- a/src/main/java/com/cloudurable/jparse/node/support/NodeUtils.java
+++ b/src/main/java/com/cloudurable/jparse/node/support/NodeUtils.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.cloudurable.jparse.token.TokenTypes.ARRAY_ITEM_TOKEN;
+
 public class NodeUtils {
 
 
@@ -26,7 +28,7 @@ public class NodeUtils {
                 break;
             }
 
-            if (token.type <= 3) {
+            if (token.type <= ARRAY_ITEM_TOKEN) {
 
                 int childCount = tokens.countChildren(index, token);
                 int endIndex = index + childCount;

--- a/src/main/java/com/cloudurable/jparse/parser/EventParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/EventParser.java
@@ -1,0 +1,14 @@
+package com.cloudurable.jparse.parser;
+
+
+import com.cloudurable.jparse.node.support.ParseConstants;
+import com.cloudurable.jparse.source.CharSource;
+import com.cloudurable.jparse.source.Sources;
+import com.cloudurable.jparse.token.TokenEventListener;
+
+public interface EventParser extends ParseConstants {
+    void parse(final CharSource source, final TokenEventListener tokenEvent);
+    default void parse(final String source, final TokenEventListener tokenEvent) {
+        parse(Sources.stringSource(source), tokenEvent);
+    }
+}

--- a/src/main/java/com/cloudurable/jparse/parser/IndexOverlayParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/IndexOverlayParser.java
@@ -1,4 +1,4 @@
-package com.cloudurable.jparse;
+package com.cloudurable.jparse.parser;
 
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.support.ParseConstants;
@@ -8,16 +8,12 @@ import com.cloudurable.jparse.token.Token;
 
 import java.util.List;
 
-public interface Parser extends ParseConstants {
-
+public interface IndexOverlayParser extends ParseConstants {
     List<Token> scan(final CharSource source);
-
     RootNode parse(final CharSource source);
-
     default RootNode parse(final String source) {
         return parse(Sources.stringSource(source));
     }
-
     default List<Token> scan(final String source) {
         return scan(Sources.stringSource(source));
     }

--- a/src/main/java/com/cloudurable/jparse/parser/JsonEventParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/JsonEventParser.java
@@ -1,0 +1,464 @@
+package com.cloudurable.jparse.parser;
+
+import com.cloudurable.jparse.node.RootNode;
+import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.source.CharSource;
+import com.cloudurable.jparse.source.support.UnexpectedCharacterException;
+import com.cloudurable.jparse.token.Token;
+import com.cloudurable.jparse.token.TokenEventListener;
+import com.cloudurable.jparse.token.TokenTypes;
+
+import java.util.List;
+
+
+public class JsonEventParser implements EventParser, IndexOverlayParser {
+    final TokenEventListener arrayItemListener = new TokenEventListener() {
+        @Override
+        public void start(int tokenId, int index, CharSource source) {
+        }
+
+        @Override
+        public void end(int tokenId, int index, CharSource source) {
+        }
+    };
+    final TokenEventListener exceptionListener = new TokenEventListener() {
+        @Override
+        public void start(int tokenId, int index, CharSource source) {
+            throw new UnexpectedCharacterException("while doing event parsing", "Unknown token id " + tokenId, source);
+        }
+
+        @Override
+        public void end(int tokenId, int index, CharSource source) {
+
+        }
+    };
+    private final boolean objectsKeysCanBeEncoded;
+    private final TokenEventListener stringListener = new ScalarListener(TokenTypes.STRING_TOKEN);
+    private final TokenEventListener floatListener = new ScalarListener(TokenTypes.FLOAT_TOKEN);
+    private final TokenEventListener intListener = new ScalarListener(TokenTypes.INT_TOKEN);
+    private final TokenEventListener booleanListener = new ScalarListener(TokenTypes.BOOLEAN_TOKEN);
+    private final TokenEventListener nullListener = new ScalarListener(TokenTypes.NULL_TOKEN);
+    final TokenEventListener base = new TokenEventListener() {
+
+        private int stackIndex = -1;
+        private TokenEventListener[] stack = new TokenEventListener[8];
+
+        @Override
+        public void start(final int tokenId, final int index, final CharSource source) {
+
+            final var listener = switch (tokenId) {
+                case TokenTypes.OBJECT_TOKEN -> new ComplexListener(TokenTypes.OBJECT_TOKEN);
+                case TokenTypes.ARRAY_TOKEN -> new ComplexListener(TokenTypes.ARRAY_TOKEN);
+                case TokenTypes.ARRAY_ITEM_TOKEN -> arrayItemListener;
+                case TokenTypes.ATTRIBUTE_KEY_TOKEN -> new ComplexListener(TokenTypes.ATTRIBUTE_KEY_TOKEN);
+                case TokenTypes.ATTRIBUTE_VALUE_TOKEN -> new ComplexListener(TokenTypes.ATTRIBUTE_VALUE_TOKEN);
+                case TokenTypes.STRING_TOKEN -> stringListener;
+                case TokenTypes.FLOAT_TOKEN -> floatListener;
+                case TokenTypes.INT_TOKEN -> intListener;
+                case TokenTypes.BOOLEAN_TOKEN -> booleanListener;
+                case TokenTypes.NULL_TOKEN -> nullListener;
+                default -> exceptionListener;
+            };
+
+            listener.start(tokenId, index, source);
+            stackIndex++;
+            if (stackIndex >= stack.length) {
+                TokenEventListener[] stackNew = new TokenEventListener[stack.length * 2];
+                System.arraycopy(stack, 0, stackNew, 0, stack.length);
+                stack = stackNew;
+            }
+            stack[stackIndex] = listener;
+        }
+
+        @Override
+        public void end(int tokenId, int index, CharSource source) {
+            stack[stackIndex].end(tokenId, index, source);
+            stack[stackIndex] = null;
+            stackIndex--;
+        }
+    };
+    private TokenList tokenList;
+
+
+    public JsonEventParser(boolean objectsKeysCanBeEncoded) {
+        this.objectsKeysCanBeEncoded = objectsKeysCanBeEncoded;
+    }
+
+    public JsonEventParser() {
+        this(false);
+    }
+
+    @Override
+    public void parse(CharSource source, final TokenEventListener event) {
+
+        int ch = source.nextSkipWhiteSpace();
+
+        for (; ch != ETX; ch = source.nextSkipWhiteSpace()) {
+
+            switch (ch) {
+                case OBJECT_START_TOKEN:
+                    parseObject(source, event);
+                    break;
+
+                case LIST_START_TOKEN:
+                    parseArray(source, event);
+                    break;
+
+                case NEW_LINE_WS:
+                case CARRIAGE_RETURN_WS:
+                case TAB_WS:
+                case SPACE_WS:
+                    continue;
+
+                case TRUE_BOOLEAN_START:
+                    parseTrue(source, event);
+                    break;
+
+                case FALSE_BOOLEAN_START:
+                    parseFalse(source, event);
+                    break;
+
+                case NULL_START:
+                    parseNull(source, event);
+                    break;
+
+                case STRING_START_TOKEN:
+                    parseString(source, event);
+                    break;
+
+                case NUM_0:
+                case NUM_1:
+                case NUM_2:
+                case NUM_3:
+                case NUM_4:
+                case NUM_5:
+                case NUM_6:
+                case NUM_7:
+                case NUM_8:
+                case NUM_9:
+                case MINUS:
+                case PLUS:
+                    parseNumber(source, event);
+                    break;
+
+                default:
+                    throw new UnexpectedCharacterException("Scanning JSON", "Unexpected character", source, (char) ch);
+            }
+
+        }
+    }
+
+    private void parseFalse(final CharSource source, final TokenEventListener event) {
+        event.start(TokenTypes.BOOLEAN_TOKEN, source.getIndex(), source);
+        event.end(TokenTypes.BOOLEAN_TOKEN, source.findFalseEnd(), source);
+    }
+
+    private void parseTrue(CharSource source, final TokenEventListener event) {
+        event.start(TokenTypes.BOOLEAN_TOKEN, source.getIndex(), source);
+        event.end(TokenTypes.BOOLEAN_TOKEN, source.findTrueEnd(), source);
+    }
+
+    private void parseNull(CharSource source, final TokenEventListener event) {
+        event.start(TokenTypes.NULL_TOKEN, source.getIndex(), source);
+        event.end(TokenTypes.NULL_TOKEN, source.findNullEnd(), source);
+    }
+
+    private void parseArray(final CharSource source, final TokenEventListener event) {
+        event.start(TokenTypes.ARRAY_TOKEN, source.getIndex(), source);
+        boolean done = false;
+        while (!done) {
+            done = parseArrayItem(source, event);
+        }
+        event.end(TokenTypes.ARRAY_TOKEN, source.getIndex() + 1, source);
+    }
+
+    private boolean parseArrayItem(CharSource source, final TokenEventListener event) {
+        int ch = source.nextSkipWhiteSpace();
+
+        forLoop:
+        for (; ch != ETX; ch = source.nextSkipWhiteSpace()) {
+
+            switch (ch) {
+                case OBJECT_START_TOKEN:
+                    event.start(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    parseObject(source, event);
+                    event.end(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    break;
+
+                case LIST_START_TOKEN:
+                    event.start(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    parseArray(source, event);
+                    event.end(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    break;
+
+                case TRUE_BOOLEAN_START:
+                    event.start(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    parseTrue(source, event);
+                    event.end(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    break;
+
+                case FALSE_BOOLEAN_START:
+                    event.start(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    parseFalse(source, event);
+                    event.end(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    break;
+
+                case NULL_START:
+                    event.start(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    parseNull(source, event);
+                    event.end(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    break;
+
+                case STRING_START_TOKEN:
+                    event.start(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    parseString(source, event);
+                    event.end(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    break;
+
+                case NUM_0:
+                case NUM_1:
+                case NUM_2:
+                case NUM_3:
+                case NUM_4:
+                case NUM_5:
+                case NUM_6:
+                case NUM_7:
+                case NUM_8:
+                case NUM_9:
+                case MINUS:
+                case PLUS:
+                    event.start(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    parseNumber(source, event);
+                    event.end(TokenTypes.ARRAY_ITEM_TOKEN, source.getIndex(), source);
+                    if (source.getCurrentChar() == LIST_END_TOKEN || source.getCurrentChar() == LIST_SEP) {
+                        if (source.getCurrentChar() == LIST_END_TOKEN) {
+                            return true;
+                        }
+                    }
+                    break;
+
+                case LIST_END_TOKEN:
+                case LIST_SEP:
+                    break forLoop;
+
+                case NEW_LINE_WS:
+                case CARRIAGE_RETURN_WS:
+                case TAB_WS:
+                case SPACE_WS:
+                    continue;
+
+                default:
+                    throw new UnexpectedCharacterException("Parsing Array Item", "Unexpected character", source, (char) ch);
+
+            }
+        }
+        return ch == LIST_END_TOKEN;
+    }
+
+    private void parseNumber(final CharSource source, final TokenEventListener event) {
+        final int startIndex = source.getIndex();
+        final var numberParse = source.findEndOfNumber();
+        final int token = numberParse.wasFloat() ? TokenTypes.FLOAT_TOKEN : TokenTypes.INT_TOKEN;
+        event.start(token, startIndex, source);
+        event.end(token, numberParse.endIndex(), source);
+    }
+
+    private void parseKey(final CharSource source, final TokenEventListener event) {
+        int ch = source.nextSkipWhiteSpace();
+        event.start(TokenTypes.ATTRIBUTE_KEY_TOKEN, source.getIndex(), source);
+        boolean done = false;
+
+        forLoop:
+        for (; ch != ETX; ch = source.nextSkipWhiteSpace()) {
+            switch (ch) {
+
+                case NEW_LINE_WS:
+                case CARRIAGE_RETURN_WS:
+                case TAB_WS:
+                case SPACE_WS:
+                    continue;
+
+                case STRING_START_TOKEN:
+                    final int strStartIndex = source.getIndex();
+                    event.start(TokenTypes.STRING_TOKEN, strStartIndex + 1, source);
+                    final int strEndIndex;
+                    if (objectsKeysCanBeEncoded) {
+                        strEndIndex = source.findEndOfEncodedString();
+                    } else {
+                        strEndIndex = source.findEndString();
+                    }
+                    event.end(TokenTypes.STRING_TOKEN, strEndIndex, source);
+                    break;
+
+                case ATTRIBUTE_SEP:
+                    event.end(TokenTypes.ATTRIBUTE_KEY_TOKEN, source.getIndex(), source);
+                    done = true;
+                    break forLoop;
+
+                default:
+                    throw new UnexpectedCharacterException("Parsing Object Key", "Unexpected character", source, (char) ch);
+            }
+        }
+
+        if (!done) {
+            throw new UnexpectedCharacterException("Parsing Object Key", "Should be done but not", source);
+        }
+    }
+
+    private boolean parseValue(final CharSource source, final TokenEventListener event) {
+        int ch = source.nextSkipWhiteSpace();
+        event.start(TokenTypes.ATTRIBUTE_VALUE_TOKEN, source.getIndex(), source);
+
+        forLoop:
+        for (; ch != ETX; ch = source.nextSkipWhiteSpace()) {
+            switch (ch) {
+                case OBJECT_START_TOKEN:
+                    parseObject(source, event);
+                    break;
+
+                case LIST_START_TOKEN:
+                    parseArray(source, event);
+                    break;
+
+                case NEW_LINE_WS:
+                case CARRIAGE_RETURN_WS:
+                case TAB_WS:
+                case SPACE_WS:
+                    continue;
+
+                case TRUE_BOOLEAN_START:
+                    parseTrue(source, event);
+                    break;
+
+                case FALSE_BOOLEAN_START:
+                    parseFalse(source, event);
+                    break;
+
+                case NULL_START:
+                    parseNull(source, event);
+                    break;
+
+                case STRING_START_TOKEN:
+                    parseString(source, event);
+                    break;
+
+                case NUM_0:
+                case NUM_1:
+                case NUM_2:
+                case NUM_3:
+                case NUM_4:
+                case NUM_5:
+                case NUM_6:
+                case NUM_7:
+                case NUM_8:
+                case NUM_9:
+                case MINUS:
+                case PLUS:
+                    parseNumber(source, event);
+                    if (source.getCurrentChar() == MAP_SEP) {
+                        event.end(TokenTypes.ATTRIBUTE_VALUE_TOKEN, source.getIndex(), source);
+                        return false;
+                    }
+                    if (source.getCurrentChar() == OBJECT_END_TOKEN) {
+                        event.end(TokenTypes.ATTRIBUTE_VALUE_TOKEN, source.getIndex(), source);
+                        return true;
+                    } else {
+                        break;
+                    }
+
+                case OBJECT_END_TOKEN:
+                case MAP_SEP:
+                    event.end(TokenTypes.ATTRIBUTE_VALUE_TOKEN, source.getIndex(), source);
+                    break forLoop;
+
+                default:
+                    throw new UnexpectedCharacterException("Parsing Value", "Unexpected character", source, ch);
+            }
+        }
+        return ch == OBJECT_END_TOKEN;
+    }
+
+    private void parseString(final CharSource source, final TokenEventListener event) {
+        event.start(TokenTypes.STRING_TOKEN, source.getIndex() + 1, source);
+        event.end(TokenTypes.STRING_TOKEN, source.findEndOfEncodedString(), source);
+    }
+
+    private void parseObject(final CharSource source, final TokenEventListener event) {
+        event.start(TokenTypes.OBJECT_TOKEN, source.getIndex(), source);
+        boolean done = false;
+        while (!done) {
+            parseKey(source, event);
+            done = parseValue(source, event);
+        }
+        event.end(TokenTypes.OBJECT_TOKEN, source.getIndex() + 1, source);
+    }
+
+    @Override
+    public List<Token> scan(final CharSource source) {
+        tokenList = new TokenList();
+        this.parse(source, base);
+        return tokenList;
+    }
+
+    @Override
+    public RootNode parse(CharSource source) {
+        return new RootNode((TokenList) scan(source), source, objectsKeysCanBeEncoded);
+    }
+
+    class ScalarListener implements TokenEventListener {
+        final int tokenType;
+        int startIndex;
+        ScalarListener(final int tokenType) {
+            this.tokenType = tokenType;
+        }
+
+        @Override
+        public void start(int tokenId, int index, CharSource source) {
+            startIndex = index;
+        }
+
+        @Override
+        public void end(int tokenId, int index, CharSource source) {
+            tokenList.add(new Token(startIndex, index, tokenType));
+        }
+
+        @Override
+        public String toString() {
+            return "ScalarListener{" +
+                    "tokenType=" + TokenTypes.getTypeName(tokenType) +
+                    ", startIndex=" + startIndex +
+                    '}';
+        }
+    }
+
+    class ComplexListener implements TokenEventListener {
+        final int tokenType;
+        int startIndex;
+        int tokenListIndex;
+
+        ComplexListener(final int tokenType) {
+            this.tokenType = tokenType;
+        }
+
+        @Override
+        public void start(int tokenId, int index, CharSource source) {
+            startIndex = index;
+            tokenListIndex = tokenList.getIndex();
+            tokenList.placeHolder();
+        }
+
+        @Override
+        public void end(int tokenId, int index, CharSource source) {
+            tokenList.set(tokenListIndex, new Token(startIndex, index, tokenType));
+        }
+
+        @Override
+        public String toString() {
+            return "ComplexListener{" +
+                    "tokenType=" + TokenTypes.getTypeName(tokenType) +
+                    ", startIndex=" + startIndex +
+                    ", tokenListIndex=" + tokenListIndex +
+                    '}';
+        }
+    }
+}

--- a/src/main/java/com/cloudurable/jparse/parser/JsonParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/JsonParser.java
@@ -1,4 +1,4 @@
-package com.cloudurable.jparse;
+package com.cloudurable.jparse.parser;
 
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.support.TokenList;
@@ -9,10 +9,9 @@ import com.cloudurable.jparse.token.TokenTypes;
 
 import java.util.List;
 
-public class JsonParser implements Parser {
+public class JsonParser implements IndexOverlayParser {
 
     private final boolean objectsKeysCanBeEncoded;
-
 
     public JsonParser() {
         this.objectsKeysCanBeEncoded = false;
@@ -22,7 +21,6 @@ public class JsonParser implements Parser {
         this.objectsKeysCanBeEncoded = objectsKeysCanBeEncoded;
 
     }
-
 
     @Override
     public List<Token> scan(final CharSource source) {
@@ -89,9 +87,7 @@ public class JsonParser implements Parser {
                 default:
                     throw new UnexpectedCharacterException("Scanning JSON", "Unexpected character", source, (char) ch);
 
-
             }
-
         }
         return tokens;
     }
@@ -201,11 +197,8 @@ public class JsonParser implements Parser {
     }
 
     private void parseNumber(final CharSource source, TokenList tokens) {
-
         final int startIndex = source.getIndex();
-
         final var numberParse = source.findEndOfNumber();
-
         tokens.add(new Token(startIndex, numberParse.endIndex(), numberParse.wasFloat() ? TokenTypes.FLOAT_TOKEN : TokenTypes.INT_TOKEN));
     }
 
@@ -220,8 +213,6 @@ public class JsonParser implements Parser {
 
         forLoop:
         for (; ch != ETX; ch = source.nextSkipWhiteSpace()) {
-
-
             switch (ch) {
 
                 case NEW_LINE_WS:
@@ -229,7 +220,6 @@ public class JsonParser implements Parser {
                 case TAB_WS:
                 case SPACE_WS:
                     continue;
-
 
                 case STRING_START_TOKEN:
                     final int strStartIndex = source.getIndex();
@@ -253,7 +243,6 @@ public class JsonParser implements Parser {
                     throw new UnexpectedCharacterException("Parsing Object Key", "Unexpected character", source, (char) ch);
 
             }
-
         }
 
         if (!done) {
@@ -291,7 +280,6 @@ public class JsonParser implements Parser {
                 case TAB_WS:
                 case SPACE_WS:
                     continue;
-
 
                 case TRUE_BOOLEAN_START:
                     parseTrue(source, tokens);
@@ -332,7 +320,6 @@ public class JsonParser implements Parser {
                         break;
                     }
 
-
                 case OBJECT_END_TOKEN:
                 case MAP_SEP:
                     if (source.getIndex() == tokenListIndex) {
@@ -357,11 +344,9 @@ public class JsonParser implements Parser {
 
 
     private void parseObject(final CharSource source, TokenList tokens) {
-
         final int startSourceIndex = source.getIndex();
         final int tokenListIndex = tokens.getIndex();
         tokens.placeHolder();
-
 
         boolean done = false;
         while (!done) {
@@ -370,7 +355,6 @@ public class JsonParser implements Parser {
             //Value
             done = parseValue(source, tokens);
         }
-
         tokens.set(tokenListIndex, new Token(startSourceIndex, source.getIndex() + 1, TokenTypes.OBJECT_TOKEN));
     }
 

--- a/src/main/java/com/cloudurable/jparse/path/PathParser.java
+++ b/src/main/java/com/cloudurable/jparse/path/PathParser.java
@@ -1,15 +1,15 @@
 package com.cloudurable.jparse.path;
 
-import com.cloudurable.jparse.Parser;
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.parser.IndexOverlayParser;
 import com.cloudurable.jparse.source.CharSource;
 import com.cloudurable.jparse.token.Token;
 import com.cloudurable.jparse.token.TokenTypes;
 
 import java.util.List;
 
-public class PathParser implements Parser {
+public class PathParser implements IndexOverlayParser {
 
 
     @Override

--- a/src/main/java/com/cloudurable/jparse/token/Token.java
+++ b/src/main/java/com/cloudurable/jparse/token/Token.java
@@ -25,4 +25,13 @@ public class Token {
     public int length() {
         return endIndex - startIndex;
     }
+
+    @Override
+    public String toString() {
+        return "Token{" +
+                "startIndex=" + startIndex +
+                ", endIndex=" + endIndex +
+                ", type=" + TokenTypes.getTypeName(type) + " " + type +
+                '}';
+    }
 }

--- a/src/main/java/com/cloudurable/jparse/token/TokenEventListener.java
+++ b/src/main/java/com/cloudurable/jparse/token/TokenEventListener.java
@@ -1,0 +1,11 @@
+package com.cloudurable.jparse.token;
+
+import com.cloudurable.jparse.source.CharSource;
+
+public interface TokenEventListener {
+
+    void start(int tokenId, int index, CharSource source);
+
+    void end(int tokenId, int index, CharSource source);
+
+}

--- a/src/main/java/com/cloudurable/jparse/token/TokenTypes.java
+++ b/src/main/java/com/cloudurable/jparse/token/TokenTypes.java
@@ -6,11 +6,31 @@ public interface TokenTypes {
     int ATTRIBUTE_KEY_TOKEN = 1;
     int ATTRIBUTE_VALUE_TOKEN = 2;
     int ARRAY_TOKEN = 3;
-    int INT_TOKEN = 4;
-    int FLOAT_TOKEN = 5;
-    int STRING_TOKEN = 6;
-    int BOOLEAN_TOKEN= 7;
-    public static final int NULL_TOKEN = 8;
-    int PATH_KEY_TOKEN = 9;
-    int PATH_INDEX_TOKEN = 10;
+    int ARRAY_ITEM_TOKEN = 4;
+
+
+    int INT_TOKEN = 5;
+    int FLOAT_TOKEN = 6;
+    int STRING_TOKEN = 7;
+    int BOOLEAN_TOKEN = 8;
+    int NULL_TOKEN = 9;
+    int PATH_KEY_TOKEN = 10;
+    int PATH_INDEX_TOKEN = 11;
+
+    static String getTypeName(final int tokenType) {
+        return switch (tokenType) {
+            case OBJECT_TOKEN -> "Object";
+            case ATTRIBUTE_KEY_TOKEN -> "Key";
+            case ATTRIBUTE_VALUE_TOKEN -> "Attribute Value";
+            case ARRAY_TOKEN -> "Array";
+            case ARRAY_ITEM_TOKEN -> "Array Item";
+            case INT_TOKEN -> "Integer";
+            case FLOAT_TOKEN -> "Float";
+            case STRING_TOKEN -> "String";
+            case BOOLEAN_TOKEN -> "Boolean";
+            case NULL_TOKEN -> "Null";
+            default -> "" + tokenType;
+
+        };
+    }
 }

--- a/src/test/java/com/cloudurable/jparse/EqualityTest.java
+++ b/src/test/java/com/cloudurable/jparse/EqualityTest.java
@@ -4,6 +4,8 @@ import com.cloudurable.jparse.node.Node;
 import com.cloudurable.jparse.node.NodeType;
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.StringNode;
+import com.cloudurable.jparse.parser.IndexOverlayParser;
+import com.cloudurable.jparse.parser.JsonParser;
 import com.cloudurable.jparse.source.Sources;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +16,7 @@ public class EqualityTest {
 
     @Test
     void testRoot() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json1 = "'abc'";
         final String json2 = "'abc'";
 
@@ -25,7 +27,7 @@ public class EqualityTest {
 
     @Test
     void testSimpleString() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json1 = "'abc'";
         final String json2 = "'abc'";
 
@@ -40,7 +42,7 @@ public class EqualityTest {
 
     @Test
     void testSimpleInt() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json1 = "1";
         final String json2 = "1";
         var v1 = getJsonRoot(parser, json1).getNumberNode();
@@ -50,7 +52,7 @@ public class EqualityTest {
 
     @Test
     void testSimpleArray() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json1 = "[1,2,3,true,false]";
         final String json2 = "[1,2,3,true,false]";
         var v1 = getJsonRoot(parser, json1).getArrayNode();
@@ -60,7 +62,7 @@ public class EqualityTest {
 
     @Test
     void testSimpleObject() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json1 = "{'1':2}";
         final String json2 = "{'1':2}";
         var v1 = getJsonRoot(parser, json1).getObjectNode();
@@ -70,7 +72,7 @@ public class EqualityTest {
 
     @Test
     void testSimpleObject2() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json1 = "{'1':2,'2':1}";
         final String json2 = "{'2':1,'1':2}";
         var v1 = getJsonRoot(parser, json1).getObjectNode();
@@ -78,7 +80,7 @@ public class EqualityTest {
         doAssert(v1, v2);
     }
 
-    private RootNode getJsonRoot(Parser parser, String json1) {
+    private RootNode getJsonRoot(IndexOverlayParser parser, String json1) {
         return parser.parse(Sources.stringSource(json1.replace("'", "\"")));
     }
 

--- a/src/test/java/com/cloudurable/jparse/JsonEventParserTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonEventParserTest.java
@@ -1,0 +1,684 @@
+package com.cloudurable.jparse;
+
+
+import com.cloudurable.jparse.node.*;
+import com.cloudurable.jparse.parser.IndexOverlayParser;
+import com.cloudurable.jparse.parser.JsonEventParser;
+import com.cloudurable.jparse.source.Sources;
+import com.cloudurable.jparse.token.TokenTypes;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import static com.cloudurable.jparse.Json.niceJson;
+import static com.cloudurable.jparse.Json.toRootNode;
+import static com.cloudurable.jparse.node.JsonTestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonEventParserTest {
+
+//
+//    @Test
+//    public void testDoubleArray() {
+//        //................012345678901234567890123
+//        final var json = "[1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9]";
+//        final double[] array = {1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9};
+//        double[] readDoubles = Json.toArrayNode(niceJson(json)).getDoubleArray();
+//        assertArrayEquals(array, readDoubles);
+//    }
+//
+//    @Test
+//    public void testDoubleArrayFast() {
+//        //................012345678901234567890123
+//        final var json = "[1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9]";
+//        final double[] array = {1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9};
+//        double[] readDoubles = Json.toArrayNode(niceJson(json)).getDoubleArrayFast();
+//        assertArrayEquals(array, readDoubles);
+//    }
+//
+//    @Test
+//    public void testFloatArray() {
+//        //................012345678901234567890123
+//        final var json = "[1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9]";
+//        final float[] array = {1, 1.1f, 1.2f, 1.3f, 1e+9f, 1e9f, 1e-9f};
+//        float[] values = Json.toArrayNode(niceJson(json)).getFloatArray();
+//        assertArrayEquals(array, values);
+//    }
+//
+//
+//    @Test
+//    public void testFloatArrayFast() {
+//        //................012345678901234567890123
+//        final var json = "[1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9]";
+//        final float[] array = {1, 1.1f, 1.2f, 1.3f, 1e+9f, 1e9f, 1e-9f};
+//        float[] values = Json.toArrayNode(niceJson(json)).getFloatArrayFast();
+//        assertArrayEquals(array, values);
+//    }
+//
+//    private BigDecimal bg(String s) {
+//        return new BigDecimal(s);
+//    }
+//
+//    @Test
+//    public void testBigDecimalArray() {
+//        //................012345678901234567890123
+//        final var json = "[1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9]";
+//        final var array = new BigDecimal[]{bg("1"), bg("1.1"), bg("1.2"), bg("1.3"), bg("1e+9"), bg("1e9"), bg("1e-9")};
+//        final var values = Json.toArrayNode(niceJson(json)).getBigDecimalArray();
+//        assertArrayEquals(array, values);
+//    }
+//
+//    private BigInteger bi(int s) {
+//        return new BigInteger("" + s);
+//    }
+//
+//    @Test
+//    public void testBigIntArray() {
+//        //................012345678901234567890123
+//        final var json = "[1, 2, 3, 4, 5, 6, 7, 8, -9]";
+//        final var array = new BigInteger[]{bi(1), bi(2), bi(3), bi(4), bi(5), bi(6), bi(7), bi(8), bi(-9)};
+//        final var values = Json.toArrayNode(niceJson(json)).getBigIntegerArray();
+//        assertArrayEquals(array, values);
+//    }
+//
+//    @Test
+//    public void testIntArray() {
+//        //................012345678901234567890123
+//        final var json = "[1, 2, 3, 4, 5, 6, 7, 8, -9]";
+//        final int[] array = {1, 2, 3, 4, 5, 6, 7, 8, -9};
+//        int[] values = Json.toArrayNode(niceJson(json)).getIntArray();
+//        assertArrayEquals(array, values);
+//    }
+//
+//    @Test
+//    public void testLongArray() {
+//        //................012345678901234567890123
+//        final var json = "[1, 2, 3, 4, 5, 6, 7, 8, 9]";
+//        final long[] array = {1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L};
+//        long [] values = Json.toArrayNode(niceJson(json)).getLongArray();
+//        assertArrayEquals(array, values);
+//    }
+//
+//    @Test
+//    public void testIntArrayFast() {
+//        //................012345678901234567890123
+//        final var json = "[1, 2, 3, 4, 5, 6, 7, 8, -9]";
+//        final int[] array = {1, 2, 3, 4, 5, 6, 7, 8, -9};
+//        int[] values =       Json.toArrayNode(niceJson(json)).getIntArrayFast();
+//        assertArrayEquals(array, values);
+//    }
+//
+//    @Test
+//    public void testLongArrayFast() {
+//        //................012345678901234567890123
+//        final var json = "[1, 2, 3, 4, 5, 6, 7, 8, 9]";
+//        final long[] array = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+//        long[] values = Json.toArrayNode(niceJson(json)).getLongArrayFast();
+//        assertArrayEquals(array, values);
+//    }
+//
+//    //-3.689349E18
+//    @Test
+//    public void testDoubleArrayExponent2() {
+//
+//        final double[] array = {3.689349E18};
+//        //...................01234567890
+//        final String json = "[3.689349E18]";
+//        double[] values = Json.toArrayNode(niceJson(json)).getDoubleArray();
+//        assertArrayEquals(array, values);
+//    }
+//
+//    @Test
+//    public void testDoubleArrayExponent() {
+//        //................012345678901234567890123
+//
+//        double value = Double.MAX_VALUE;
+//        final double unitDown = Double.MAX_VALUE / 10;
+//
+//        final var buf = new StringBuilder();
+//        final var numbers = new ArrayList<Double>();
+//        buf.append('[');
+//
+//        for (int i = 0; i < 5; i++) {
+//            value = value - (i * unitDown);
+//            String format = String.format("%e", value);
+//            numbers.add(Double.parseDouble(format));
+//            buf.append(format).append(",");
+//        }
+//
+//        value = Double.MIN_VALUE;
+//        for (int i = 0; i < 4; i++) {
+//            value = value + (i * unitDown);
+//            String format = String.format("%e", value);
+//            numbers.add(Double.parseDouble(format));
+//            buf.append(format).append(",");
+//        }
+//
+//        buf.setCharAt(buf.length() - 1, ']');
+//
+//        final var json = buf.toString();
+//
+//        double[] readDoubles = Json.toArrayNode(niceJson(json)).getDoubleArray();
+//
+//        for (int i = 0; i < readDoubles.length; i++) {
+//            //System.out.println(numbers.get(i) + "    " +  readDoubles[i]);
+//            assertEquals(numbers.get(i), readDoubles[i], Math.abs(numbers.get(i) / 10_000.0));
+//        }
+//
+//
+//        //assertArrayEquals(array, readDoubles);
+//    }
+//
+//
+//    @Test
+//    public void testDoubleArrayLarge() {
+//        //................012345678901234567890123
+//
+//        double value = Long.MAX_VALUE;
+//        final double unitDown = Long.MAX_VALUE / 10;
+//
+//        final var buf = new StringBuilder();
+//        final var numbers = new ArrayList<Double>();
+//        buf.append('[');
+//
+//        for (int i = 0; i < 5; i++) {
+//            value = value - (i * unitDown);
+//            String format = String.format("%f", value);
+//            numbers.add(Double.parseDouble(format));
+//            buf.append(format).append(",");
+//        }
+//
+//        value = Long.MIN_VALUE;
+//        for (int i = 0; i < 4; i++) {
+//            value = value + (i * unitDown);
+//            String format = String.format("%e", value);
+//            numbers.add(Double.parseDouble(format));
+//            buf.append(format).append(",");
+//        }
+//
+//        buf.setCharAt(buf.length() - 1, ']');
+//
+//
+//        final var json = buf.toString();
+//        //System.out.println(json);
+//
+//        double[] readDoubles = Json.toArrayNode(niceJson(json)).getDoubleArray();
+//
+//        for (int i = 0; i < readDoubles.length; i++) {
+//
+//            //.println(numbers.get(i) + "    " +  readDoubles[i]);
+//
+//            assertEquals(numbers.get(i), readDoubles[i], Math.abs(numbers.get(i) / 10_000.0));
+//        }
+//
+//
+//        //assertArrayEquals(array, readDoubles);
+//    }
+//
+//    @Test
+//    public void testComplexMap() {
+//        //................012345678901234567890123
+//        final var json = "{'1':2,'2':7,'3':[1,2,3]}";
+//        final RootNode root = nodeRoot(json);
+//
+//        final var jsonObject = root.getMap();
+//        assertEquals(2, asInt(jsonObject, "1"));
+//        assertEquals(7, asInt(jsonObject, "2"));
+//        assertEquals(List.of(1L, 2L, 3L), asArray(jsonObject, "3").stream().map(n->n.asScalar().longValue()).collect(Collectors.toList()));
+//
+//    }
+//
+//    @Test
+//    void testParseNumberJsonElement() {
+//        final IndexOverlayParser parser = new JsonParser();
+//        final String json = "1";
+//        RootNode jsonRoot = parser.parse(Sources.stringSource(json));
+//        assertEquals(1, jsonRoot.getInt());
+//        assertEquals(1, jsonRoot.getLong());
+//        assertEquals(new BigInteger("1"), jsonRoot.getBigIntegerValue());
+//        assertTrue(jsonRoot.getNode().isScalar());
+//        assertFalse(jsonRoot.getNode().isCollection());
+//    }
+//
+//    @Test
+//    void testParseFloatJsonElement() {
+//        final IndexOverlayParser parser = new JsonParser();
+//        final String json = "1.1";
+//        RootNode jsonRoot = parser.parse(Sources.stringSource(json));
+//        assertEquals(1.1, jsonRoot.getFloat(), 0.001);
+//        assertEquals(1.1, jsonRoot.getDouble(), 0.001);
+//        assertEquals(new BigDecimal("1.1"), jsonRoot.getBigDecimal());
+//    }
+//
+//
+//    @Test
+//    public void testComplexMapWithMixedKeys() {
+//        //................012345678901234567890123
+//        final var json = "{'1':2,'2':7,'abc':[1,2,3,true,'hi'],'4':true}";
+//        final RootNode root = nodeRoot(json);
+//        final var jsonObject = Json.toMap(niceJson(json));
+//        assertTrue(asBoolean(jsonObject, "4"));
+//        assertEquals(2, asInt(jsonObject, "1"));
+//        assertEquals(7, asInt(jsonObject, "2"));
+//        assertEquals(7, asShort(jsonObject, "2"));
+//        assertEquals(7L, asLong(jsonObject, "2"));
+//        assertEquals(7.0, asDouble(jsonObject, "2"));
+//        assertEquals(7.0f, asFloat(jsonObject, "2"));
+//        assertEquals(new BigInteger("7"), asBigInteger(jsonObject, "2"));
+//        assertEquals(new BigDecimal("7"), asBigDecimal(jsonObject, "2"));
+//
+//        assertEquals(List.of(1, 2, 3, true, "hi"), asArray(jsonObject, "abc").stream().map(n->n.asScalar().value()).collect(Collectors.toList()));
+//
+//        assertEquals(1, asInt(asList(jsonObject, "abc"), 0));
+//        assertEquals("hi", asString(asList(jsonObject, "abc"), 4));
+//        assertEquals("hi", asString(asList(jsonObject, "abc"), 4));
+//        assertEquals(1, asShort(asList(jsonObject, "abc"), 0));
+//        assertEquals(1.0, asDouble(asList(jsonObject, "abc"), 0));
+//        assertEquals(1.0f, asFloat(asList(jsonObject, "abc"), 0));
+//        assertEquals(1L, asLong(asList(jsonObject, "abc"), 0));
+//        assertEquals(new BigInteger("1"), asBigInteger(asList(jsonObject, "abc"), 0));
+//        assertEquals(new BigDecimal("1"), asBigDecimal(asList(jsonObject, "abc"), 0));
+//
+//        assertTrue(asBoolean(asList(jsonObject, "abc"), 3));
+//        assertTrue(asArray(jsonObject, "abc").getBooleanNode(3).booleanValue());
+//        assertTrue(asArray(jsonObject, "abc").getBoolean(3));
+//
+//        assertFalse(root.getNode().isScalar());
+//        assertTrue(root.getNode().isCollection());
+//
+//    }
+
+
+    @Test
+    void testSimpleBooleanTrue() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "true";
+
+        final var tokens = parser.scan(Sources.charSeqSource(json));
+
+
+        final RootNode jsonRoot = parser.parse(Sources.charSeqSource(json));
+        assertTrue(jsonRoot.getBooleanNode().booleanValue());
+        assertTrue(jsonRoot.getBoolean());
+
+        assertEquals(json, jsonRoot.getBooleanNode().toString());
+        assertEquals(json, jsonRoot.getBooleanNode().charSource().toString());
+
+        assertEquals(json.charAt(0), jsonRoot.getBooleanNode().charAt(0));
+        assertEquals(json.charAt(1), jsonRoot.getBooleanNode().charAt(1));
+        assertEquals(json.charAt(2), jsonRoot.getBooleanNode().charAt(2));
+        assertEquals(json.charAt(3), jsonRoot.getBooleanNode().charAt(3));
+
+        assertEquals(4, jsonRoot.getBooleanNode().length());
+        assertEquals(NodeType.BOOLEAN, jsonRoot.getBooleanNode().type());
+        assertEquals(TokenTypes.BOOLEAN_TOKEN, jsonRoot.getBooleanNode().rootElementToken().type);
+        assertEquals(TokenTypes.BOOLEAN_TOKEN, jsonRoot.getBooleanNode().tokens().get(0).type);
+    }
+
+
+    @Test
+    void testSimpleNull() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "null";
+
+        final RootNode jsonRoot = parser.parse(Sources.charSeqSource(json));
+
+        assertEquals(json, jsonRoot.getNullNode().toString());
+        assertEquals(json, jsonRoot.getNullNode().charSource().toString());
+
+        assertEquals(json.charAt(0), jsonRoot.getNullNode().charAt(0));
+        assertEquals(json.charAt(1), jsonRoot.getNullNode().charAt(1));
+        assertEquals(json.charAt(2), jsonRoot.getNullNode().charAt(2));
+        assertEquals(json.charAt(3), jsonRoot.getNullNode().charAt(3));
+
+        assertEquals(4, jsonRoot.getNullNode().length());
+        assertEquals(NodeType.NULL, jsonRoot.getNullNode().type());
+        assertEquals(TokenTypes.NULL_TOKEN, jsonRoot.getNullNode().rootElementToken().type);
+        assertEquals(TokenTypes.NULL_TOKEN, jsonRoot.getNullNode().tokens().get(0).type);
+    }
+
+    @Test
+    void testSimpleBooleanFalse() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "false";
+
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json));
+        assertFalse(jsonRoot.getBooleanNode().booleanValue());
+
+        assertEquals(json, jsonRoot.getBooleanNode().toString());
+        assertEquals(json, jsonRoot.getBooleanNode().charSource().toString());
+
+        assertEquals(json.charAt(0), jsonRoot.getBooleanNode().charAt(0));
+        assertEquals(json.charAt(1), jsonRoot.getBooleanNode().charAt(1));
+        assertEquals(json.charAt(2), jsonRoot.getBooleanNode().charAt(2));
+        assertEquals(json.charAt(3), jsonRoot.getBooleanNode().charAt(3));
+        assertEquals(json.charAt(4), jsonRoot.getBooleanNode().charAt(4));
+
+        assertEquals(5, jsonRoot.getBooleanNode().length());
+        assertEquals(NodeType.BOOLEAN, jsonRoot.getBooleanNode().type());
+        assertEquals(TokenTypes.BOOLEAN_TOKEN, jsonRoot.getBooleanNode().rootElementToken().type);
+        assertEquals(TokenTypes.BOOLEAN_TOKEN, jsonRoot.getBooleanNode().tokens().get(0).type);
+    }
+
+
+    @Test
+    void testSimpleString() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "\"abc\"";
+
+        final RootNode jsonRoot = parser.parse(Sources.charSeqSource(json));
+        assertEquals("abc", jsonRoot.getStringNode().toString());
+        assertEquals(NodeType.STRING, jsonRoot.getType());
+        assertEquals("bc", jsonRoot.getStringNode().subSequence(1, 3).toString());
+    }
+
+    @Test
+    void testSimpleEncodedString() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        //....................012 3 4 5 6
+        final String json = "'abc`n`b`r`u1234'";
+
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"").replace('`', '\\')));
+
+        final var encodedString = jsonRoot.getStringNode().toString();
+        final var unencodedString = jsonRoot.getStringNode().toUnencodedString();
+
+        assertEquals("abc\\n\\b\\r\\u1234", unencodedString);
+        assertEquals("abc\n\b\r\u1234", encodedString);
+        assertEquals("abc\n\b\r\u1234", jsonRoot.getStringNode().toString());
+        assertEquals(7, jsonRoot.getStringNode().toEncodedString().length());
+        assertEquals(NodeType.STRING, jsonRoot.getType());
+        assertEquals("bc", jsonRoot.getStringNode().subSequence(1, 3).toString());
+
+        assertEquals('\n', jsonRoot.getStringNode().toEncodedString().charAt(3));
+    }
+
+    @Test
+    void testGetNumFloat() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "1.1";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+        assertEquals(1.1, jsonRoot.getNumberNode().floatValue(), 0.001);
+        assertEquals(NodeType.FLOAT, jsonRoot.getType());
+    }
+
+    @Test
+    void testGetNumInt() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "1";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+        assertEquals(1.0, jsonRoot.getNumberNode().floatValue(), 0.001);
+        assertEquals(NodeType.INT, jsonRoot.getType());
+    }
+
+
+    @Test
+    void testSimpleStringFromMap() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "{'a':'abc'}";
+
+        final RootNode jsonRoot = parser.parse(niceJson(json));
+
+        StringNode aStringValue = jsonRoot.getObjectNode().getStringNode("a");
+        //assertEquals("abc", jsonRoot.getObject().getValue("a").toString());
+        assertEquals("abc", aStringValue.toString());
+        assertEquals("abc", jsonRoot.getObjectNode().getString("a"));
+
+        assertEquals(NodeType.OBJECT, jsonRoot.getType());
+
+        assertEquals(1, jsonRoot.getObjectNode().length());
+        //assertEquals(List.of(new StringNode("a", 0, 1)), jsonRoot.getObjectNode().getKeys());
+
+        assertEquals(niceJson("abc"), jsonRoot.getObjectNode().getString("a"));
+
+        assertEquals(niceJson(json), jsonRoot.originalString());
+    }
+
+
+    @Test
+    void testSimpleStringFromMap3() {
+        final var json = "{'a':null}";
+        final IndexOverlayParser parser = new JsonEventParser();
+        final RootNode root = parser.parse(niceJson(json));
+
+        final var nullNode = root.getNode("a");
+        assertEquals("null", nullNode.toString());
+        assertEquals(4, nullNode.length());
+        assertEquals('n', nullNode.charAt(0));
+        assertEquals('u', nullNode.charAt(1));
+        assertEquals('l', nullNode.charAt(2));
+        assertEquals('l', nullNode.charAt(3));
+
+    }
+
+
+    @Test
+    void test3ItemMap() {
+        //...................012345678901234567890
+        final String json = "{'a':'abc','b':'def', 'c': true}";
+
+
+        final IndexOverlayParser parser = new JsonEventParser();
+        final RootNode jsonRoot = parser.parse(niceJson(json));
+
+        assertEquals(3, jsonRoot.getObjectNode().length());
+        assertEquals(NodeType.OBJECT, jsonRoot.getType());
+        assertEquals("abc", jsonRoot.getObjectNode().getNode("a").toString());
+        assertEquals("def", jsonRoot.getObjectNode().getStringNode("b").toString());
+        assertTrue(jsonRoot.getObjectNode().getBooleanNode("c").booleanValue());
+        assertTrue(jsonRoot.getObjectNode().getBoolean("c"));
+    }
+
+    @Test
+    void test2ItemIntKeyMap() {
+
+        //...................0123456789
+        final String json = "{'1':2,'2':3}";
+
+        final IndexOverlayParser parser = new JsonEventParser();
+        final RootNode jsonRoot = parser.parse(niceJson(json));
+
+        assertEquals(2, jsonRoot.getObjectNode().length());
+        assertEquals(3, jsonRoot.getObjectNode().getLong("2"));
+
+        assertEquals(new BigInteger("3"), jsonRoot.getObjectNode().getBigInteger("2"));
+        assertEquals(new BigDecimal("3"), jsonRoot.getObjectNode().getBigDecimal("2"));
+
+        assertEquals(2, jsonRoot.getObjectNode().getLong("1"));
+        assertEquals(3, jsonRoot.getObjectNode().getInt("2"));
+        assertEquals(2, jsonRoot.getObjectNode().getInt("1"));
+        assertEquals(NodeType.OBJECT, jsonRoot.getType());
+    }
+
+    @Test
+    void testSimpleMapFromMap() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "{'a':{'a':'abc'}}";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+        assertEquals("abc", jsonRoot.getObjectNode().getObjectNode("a").getStringNode("a").toString());
+        assertEquals(NodeType.OBJECT, jsonRoot.getType());
+        assertEquals(NodeType.OBJECT, jsonRoot.getObjectNode().type());
+
+
+        assertEquals(niceJson("{'a':'abc'}"), jsonRoot.getObjectNode().getObjectNode("a").originalString());
+        assertEquals(niceJson("{'a':'abc'}"), jsonRoot.getObjectNode().getObjectNode("a").originalCharSequence().toString());
+
+    }
+
+    @Test
+    void testSimpleArrayFromMap() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final var json = "{'a':[1,2,3]}";
+        final var jsonRoot = parser.parse(niceJson(json));
+
+        final var jsonObject = jsonRoot.asObject();
+
+
+        final var hash = jsonObject.hashCode();
+        assertEquals(hash, jsonObject.hashCode());
+        assertEquals(nodeObject(json), jsonObject);
+
+        jsonObject.entrySet().forEach(objectObjectEntry -> assertTrue(jsonObject.containsKey(objectObjectEntry.getKey())));
+    }
+
+    @Test
+    void testSimpleIntFromArray() {
+        final var json = "[1,2,3]";
+        final var jsonArray = new JsonEventParser().parse(niceJson(json)).asArray();
+        assertEquals(1L, jsonArray.getLong(0));
+        assertEquals(1, jsonArray.getNumberNode(0).intValue());
+        assertEquals(1, jsonArray.getNumberNode(0).longValue());
+    }
+
+    @Test
+    void testSimpleFloatFromArray() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "[1.1,2,3]";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+        assertEquals(1.1, jsonRoot.getArrayNode().getDouble(0), 0.001);
+        assertEquals(1.1, jsonRoot.getArrayNode().getFloat(0), 0.001);
+        assertEquals(new BigDecimal("1.1"), jsonRoot.getArrayNode().getBigDecimal(0));
+        assertEquals(new BigInteger("2"), jsonRoot.getArrayNode().getBigInteger(1));
+
+        assertEquals(1.1, jsonRoot.getArrayNode().getNumberNode(0).floatValue(), 0.001);
+        assertEquals(1.1, jsonRoot.getArrayNode().getNumberNode(0).doubleValue(), 0.001);
+    }
+
+    @Test
+    void testSimpleNullFromArray() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "[null,2,null]";
+        final RootNode jsonRoot = toRootNode(json);
+        NullNode nullNode = jsonRoot.getArrayNode().getNullNode(0);
+        assertEquals("null", nullNode.toString());
+
+        assertNull(jsonRoot.getArrayNode().get(0));
+
+    }
+
+    @Test
+    void testSimpleArrayFromArray() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        //...................012345678901234
+        final String json = "[[1,2,3],2,3]";
+        final RootNode jsonRoot = parser.parse(niceJson(json));
+        assertEquals(1L, jsonRoot.getArrayNode().getArray(0).getLong(0));
+        assertEquals(1, jsonRoot.getArrayNode().getArray(0).getNumberNode(0).intValue());
+        assertEquals(3, jsonRoot.getArrayNode().getArray(0).length());
+    }
+
+
+    @Test
+    void testGeFloatFromMap() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "{'a':1.1}";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+        assertEquals(1.1, jsonRoot.getObjectNode().getDouble("a"), 0.001);
+        assertEquals(1.1, jsonRoot.getObjectNode().getFloat("a"), 0.001);
+
+        assertEquals(NodeType.OBJECT, jsonRoot.getType());
+    }
+
+    @Test
+    void testGetIntFromMap() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        //...................0123
+        final String json = "{'a':1}";
+        final RootNode jsonRoot = nodeRoot(json);
+        assertEquals(1, jsonRoot.getObjectNode().getLong("a"));
+        assertEquals(1, jsonRoot.getObjectNode().getNumberNode("a").intValue());
+        assertEquals(NodeType.OBJECT, jsonRoot.getType());
+    }
+
+    @Test
+    void testGetItemFromMap() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "{'a':1}";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+        assertNotNull(jsonRoot.getObjectNode().getNumberNode("a"));
+        assertNull(jsonRoot.getObjectNode().getNumberNode("b"));
+        assertNull(jsonRoot.getObjectNode().getNumberNode("abc"));
+
+    }
+
+    @Test
+    void testSimpleList() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "['h','a',true,false]";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+        String s = jsonRoot.getArrayNode().getStringNode(0).toString();
+        assertEquals("h", "h");
+        assertEquals("a", jsonRoot.getArrayNode().getStringNode(1).toString());
+        assertEquals("a", jsonRoot.getArrayNode().getString(1));
+        assertTrue(jsonRoot.getArrayNode().getBooleanNode(2).booleanValue());
+        assertFalse(jsonRoot.getArrayNode().getBooleanNode(3).booleanValue());
+    }
+
+    @Test
+    void testSimpleListWithInts() {
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "[1,3]";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+        assertEquals(1L, jsonRoot.getArrayNode().getLong(0));
+        assertEquals(3L, jsonRoot.getArrayNode().getLong(1));
+    }
+
+    @Test
+    void testObjectGetOperation() {
+
+        final IndexOverlayParser parser = new JsonEventParser();
+        //...................012345678
+        final String json = "{'h':'a'}";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+
+        String hVal = jsonRoot.getObjectNode().getStringNode("h").toString();
+        assertEquals("a", hVal);
+
+    }
+
+    @Test
+    void testSingletonListWithOneObject() {
+
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "[ { 'h' : 'a' } ]";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+
+        String hVal = jsonRoot.getArrayNode().getObject(0).getStringNode("h").toString();
+        assertEquals("a", "a");
+
+    }
+
+    @Test
+    void testSingletonListWithOneObjectNoSpaces() {
+
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "[{'h':'a'}]";
+        final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
+
+        final ObjectNode object = jsonRoot.getArrayNode().getObject(0);
+
+        final StringNode h = object.getStringNode("h");
+
+        final String hVal = h.toString();
+        assertEquals("a", hVal);
+
+    }
+
+    @Test
+    void glossaryBug() {
+
+        final IndexOverlayParser parser = new JsonEventParser();
+        final String json = "{\n" +
+                "\n" +
+                "    \"score\": 0.1\n" +
+                "}\n";
+        final RootNode jsonRoot = parser.parse(json);
+
+
+
+    }
+
+
+
+}

--- a/src/test/java/com/cloudurable/jparse/JsonParserTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonParserTest.java
@@ -2,6 +2,8 @@ package com.cloudurable.jparse;
 
 
 import com.cloudurable.jparse.node.*;
+import com.cloudurable.jparse.parser.IndexOverlayParser;
+import com.cloudurable.jparse.parser.JsonParser;
 import com.cloudurable.jparse.source.Sources;
 import com.cloudurable.jparse.token.TokenTypes;
 import org.junit.jupiter.api.Test;
@@ -236,7 +238,7 @@ class JsonParserTest {
 
     @Test
     void testParseNumberJsonElement() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "1";
         RootNode jsonRoot = parser.parse(Sources.stringSource(json));
         assertEquals(1, jsonRoot.getInt());
@@ -248,7 +250,7 @@ class JsonParserTest {
 
     @Test
     void testParseFloatJsonElement() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "1.1";
         RootNode jsonRoot = parser.parse(Sources.stringSource(json));
         assertEquals(1.1, jsonRoot.getFloat(), 0.001);
@@ -297,7 +299,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleBooleanTrue() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "true";
 
         final RootNode jsonRoot = parser.parse(Sources.charSeqSource(json));
@@ -321,7 +323,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleNull() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "null";
 
         final RootNode jsonRoot = parser.parse(Sources.charSeqSource(json));
@@ -342,7 +344,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleBooleanFalse() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "false";
 
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json));
@@ -366,7 +368,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleString() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "\"abc\"";
 
         final RootNode jsonRoot = parser.parse(Sources.charSeqSource(json));
@@ -377,7 +379,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleEncodedString() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //....................012 3 4 5 6
         final String json = "'abc`n`b`r`u1234'";
 
@@ -398,7 +400,7 @@ class JsonParserTest {
 
     @Test
     void testGetNumFloat() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "1.1";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         assertEquals(1.1, jsonRoot.getNumberNode().floatValue(), 0.001);
@@ -407,7 +409,7 @@ class JsonParserTest {
 
     @Test
     void testGetNumInt() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "1";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         assertEquals(1.0, jsonRoot.getNumberNode().floatValue(), 0.001);
@@ -417,7 +419,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleStringFromMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'a':'abc'}";
         final RootNode jsonRoot = parser.parse(json.replace("'", "\""));
 
@@ -465,7 +467,7 @@ class JsonParserTest {
 
     @Test
     void test3ItemMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................012345678901234567890
         final String json = "{'a':'abc','b':'def', 'c': true}";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
@@ -479,7 +481,7 @@ class JsonParserTest {
 
     @Test
     void test2ItemIntKeyMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................0123456789
         final String json = "{'1':2,'2':3}";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
@@ -497,7 +499,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleMapFromMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'a':{'a':'abc'}}";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         assertEquals("abc", jsonRoot.getObjectNode().getObjectNode("a").getStringNode("a").toString());
@@ -560,7 +562,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleFloatFromArray() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "[1.1,2,3]";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         assertEquals(1.1, jsonRoot.getArrayNode().getDouble(0), 0.001);
@@ -574,7 +576,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleNullFromArray() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "[null,2,null]";
         final RootNode jsonRoot = toRootNode(json);
         NullNode nullNode = jsonRoot.getArrayNode().getNullNode(0);
@@ -586,7 +588,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleArrayFromArray() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "[[1,2,3],2,3]";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         assertEquals(1L, jsonRoot.getArrayNode().getArray(0).getLong(0));
@@ -618,7 +620,7 @@ class JsonParserTest {
 
     @Test
     void testGeFloatFromMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'a':1.1}";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         assertEquals(1.1, jsonRoot.getObjectNode().getDouble("a"), 0.001);
@@ -629,7 +631,7 @@ class JsonParserTest {
 
     @Test
     void testGetIntFromMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................0123
         final String json = "{'a':1}";
         final RootNode jsonRoot = nodeRoot(json);
@@ -640,7 +642,7 @@ class JsonParserTest {
 
     @Test
     void testGetItemFromMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'a':1}";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         assertNotNull(jsonRoot.getObjectNode().getNumberNode("a"));
@@ -651,7 +653,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleList() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "['h','a',true,false]";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         String s = jsonRoot.getArrayNode().getStringNode(0).toString();
@@ -664,7 +666,7 @@ class JsonParserTest {
 
     @Test
     void testSimpleListWithInts() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "[1,3]";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
         assertEquals(1L, jsonRoot.getArrayNode().getLong(0));
@@ -674,7 +676,7 @@ class JsonParserTest {
     @Test
     void testObjectGetOperation() {
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................012345678
         final String json = "{'h':'a'}";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
@@ -687,7 +689,7 @@ class JsonParserTest {
     @Test
     void testSingletonListWithOneObject() {
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "[ { 'h' : 'a' } ]";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
 
@@ -699,7 +701,7 @@ class JsonParserTest {
     @Test
     void testSingletonListWithOneObjectNoSpaces() {
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "[{'h':'a'}]";
         final RootNode jsonRoot = parser.parse(Sources.stringSource(json.replace("'", "\"")));
 

--- a/src/test/java/com/cloudurable/jparse/JsonScannerTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonScannerTest.java
@@ -1,6 +1,8 @@
 package com.cloudurable.jparse;
 
 
+import com.cloudurable.jparse.parser.IndexOverlayParser;
+import com.cloudurable.jparse.parser.JsonParser;
 import com.cloudurable.jparse.source.Sources;
 import com.cloudurable.jparse.token.Token;
 import com.cloudurable.jparse.token.TokenTypes;
@@ -51,7 +53,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleListWithInts() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................0123456
         final String json = "[ 1 , 3 ]";
 
@@ -75,7 +77,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleListWithIntsNoSpaces() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................0123456
         final String json = "[1,3]";
 
@@ -101,7 +103,7 @@ class JsonScannerTest {
     void testSimpleList() {
 
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //0123456789
         final String json = "['h','a']";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -128,7 +130,7 @@ class JsonScannerTest {
     @Test
     void testSingletonListWithOneObject() {
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "[{'h':'a'}]";
         final List<Token> tokens = parser.scan(Sources.charSeqSource(json.replace("'", "\"")));
 
@@ -143,7 +145,7 @@ class JsonScannerTest {
 
     @Test
     void testListOfObjects() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................01234567890123456789012
         final String json = "[{'h':'a'},{'i':'b'}]";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -157,7 +159,7 @@ class JsonScannerTest {
 
     @Test
     void testMapTwoItems() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................01234567890123456789012
         final String json = "{'h':'a', 'i':'b'}";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -171,7 +173,7 @@ class JsonScannerTest {
     @Test
     void testListOfLists() {
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "[['h','a'],['i','b']]";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
 
@@ -190,7 +192,7 @@ class JsonScannerTest {
     @Test
     void testStringKey() {
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'1':1}";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
 
@@ -204,7 +206,7 @@ class JsonScannerTest {
 
     @Test
     void test2ItemIntKeyMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'1':2,'2':3}";
 
         final var tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -236,7 +238,7 @@ class JsonScannerTest {
 
     @Test
     void testParseNumber() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //0123456789
         final String json = "1";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -250,7 +252,7 @@ class JsonScannerTest {
 
     @Test
     void testParseNumberFloat() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................0123456789
         final String json = "1.1";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -264,7 +266,7 @@ class JsonScannerTest {
 
     @Test
     void testParseNumberFloat2() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................0123456789
         final String json = "1.1e-12";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -278,7 +280,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleListStrNum() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //0123456789
         final String json = "['h',1]";
 
@@ -303,7 +305,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleListStrStr() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //0123456789
         final String json = "['h','i']";
 
@@ -326,7 +328,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleObject() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //0123456789
         final String json = "{'h':'a'}";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -360,7 +362,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleObjectNumberValue() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //0123456789
         final String json = "{'h' : 1 }";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -394,7 +396,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleObjectTwoItems() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //01234567890123456789
         final String json = "{'h':'a', 'i':'b'}";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -451,7 +453,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleObjectTwoItemsWeirdSpacing() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //01234567890123456789
         final String json = "   {'h':   'a',\n\t 'i':'b'\n\t } \n\t    \n";
         final List<Token> tokens = parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -489,7 +491,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleString() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String str = "h";
         final String json = String.format("\"%s\"", str);
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -502,7 +504,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleStringSkipWhiteSpace() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String str = "hi mom";
         final String json = String.format("     \"%s\"     ", str);
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -515,7 +517,7 @@ class JsonScannerTest {
 
     @Test
     void testStringHandleControlChars() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String str = "hi mom \\\" \\n \\t all good";
         final String json = String.format("     \"%s\"     ", str);
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -528,7 +530,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleNumber() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "1 ";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -541,7 +543,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleNumberNoSpace() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "1";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -555,7 +557,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleLongNumber() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "1234567890 ";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -572,7 +574,7 @@ class JsonScannerTest {
 
     @Test
     void testSimpleLongNoSpace() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "1234567890";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -589,7 +591,7 @@ class JsonScannerTest {
 
     @Test
     void testDecimal() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "1.12 ";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -606,7 +608,7 @@ class JsonScannerTest {
 
     @Test
     void testDecimalNoSpace() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "1.12";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -623,7 +625,7 @@ class JsonScannerTest {
 
     @Test
     void testDecimalWithExponent() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "1.12e5";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -640,7 +642,7 @@ class JsonScannerTest {
 
     @Test
     void testDecimalOneEFive() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "1e5";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));
@@ -657,7 +659,7 @@ class JsonScannerTest {
 
     @Test
     void testBadChar() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "@";
         try {
@@ -672,7 +674,7 @@ class JsonScannerTest {
 
     @Test
     void testBadCharInNumber() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "123@";
         try {
@@ -686,7 +688,7 @@ class JsonScannerTest {
 
     @Test
     void testBadCharInFloat() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "123.1@";
         try {
@@ -700,7 +702,7 @@ class JsonScannerTest {
 
     @Test
     void testTooManySignOperators() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "123.1e-+1";
         try {
@@ -714,7 +716,7 @@ class JsonScannerTest {
 
     @Test
     void testUnexpectedExponentChar() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "123.1e-@";
         try {
@@ -728,7 +730,7 @@ class JsonScannerTest {
 
     @Test
     void testUnexpectedList() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "[1,@]";
         try {
@@ -742,7 +744,7 @@ class JsonScannerTest {
 
     @Test
     void testUnexpectedMapValue() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "{1:@}";
         try {
@@ -756,7 +758,7 @@ class JsonScannerTest {
 
     @Test
     void testUnexpectedKey() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "{@:1}";
         try {
@@ -770,7 +772,7 @@ class JsonScannerTest {
 
     @Test
     void testUnexpectedEndKeyKey() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "{:1}";
         try {
@@ -784,7 +786,7 @@ class JsonScannerTest {
 
     @Test
     void testUnexpectedEndOfMapValue() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "{1:}";
         try {
@@ -799,7 +801,7 @@ class JsonScannerTest {
 
     @Test
     void stringNotClosed() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "\"hello cruel world'";
         try {
@@ -813,7 +815,7 @@ class JsonScannerTest {
 
     @Test
     void testParseFloatWithExponentMarkerInList() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
 
         final String json = "[123.1e-9]";
         final List<Token> tokens = parser.scan(Sources.stringSource(json));

--- a/src/test/java/com/cloudurable/jparse/ObjectSerializerTest.java
+++ b/src/test/java/com/cloudurable/jparse/ObjectSerializerTest.java
@@ -2,6 +2,8 @@ package com.cloudurable.jparse;
 
 import com.cloudurable.jparse.node.ArrayNode;
 import com.cloudurable.jparse.node.RootNode;
+import com.cloudurable.jparse.parser.IndexOverlayParser;
+import com.cloudurable.jparse.parser.JsonParser;
 import com.cloudurable.jparse.source.Sources;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +17,7 @@ public class ObjectSerializerTest {
 
     @Test
     public void testMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'1':2,'2':7}";
         var elementMap = getJsonRoot(parser, json).getObjectNode().asObject();
         assertEquals(2L, elementMap.get("1").asScalar().longValue());
@@ -25,7 +27,7 @@ public class ObjectSerializerTest {
 
     @Test
     public void testMapBig() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'1':2,'2':7}";
         var elementMap = getJsonRoot(parser, json).getObjectNode().asObject();
         assertEquals(new BigInteger("2"), elementMap.get("1").asScalar().bigIntegerValue());
@@ -33,7 +35,7 @@ public class ObjectSerializerTest {
 
     @Test
     public void testJsonObjectIsAMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'1':2.2,'2':7}";
         var elementMap = getJsonRoot(parser, json).getMap();
         assertEquals(2.2f, asFloat(elementMap, "1"));
@@ -44,7 +46,7 @@ public class ObjectSerializerTest {
 
     @Test
     public void testList() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "['1',2,2.2]";
         var elementList = getJsonRoot(parser, json).getArrayNode().asArray();
         var list = getJsonRoot(parser, json).getArrayNode();
@@ -55,7 +57,7 @@ public class ObjectSerializerTest {
 
     @Test
     public void testComplexList() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "['1',2,2.2,[1,2,3]]";
         var elementList = getJsonRoot(parser, json).getArrayNode().asArray();
         var list = getJsonRoot(parser, json).getArrayNode();
@@ -68,7 +70,7 @@ public class ObjectSerializerTest {
 
     @Test
     public void testComplexMap() {
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         final String json = "{'1':2,'2':7,'abc':[1,2,3]}";
         var elementMap = getJsonRoot(parser, json).getObjectNode();
         var map = getJsonRoot(parser, json).getObjectNode();
@@ -79,7 +81,7 @@ public class ObjectSerializerTest {
     }
 
 
-    private RootNode getJsonRoot(Parser parser, String json1) {
+    private RootNode getJsonRoot(IndexOverlayParser parser, String json1) {
         return parser.parse(Sources.stringSource(json1.replace("'", "\"")));
     }
 

--- a/src/test/java/com/cloudurable/jparse/TestKeyLookUp.java
+++ b/src/test/java/com/cloudurable/jparse/TestKeyLookUp.java
@@ -2,6 +2,8 @@ package com.cloudurable.jparse;
 
 import com.cloudurable.jparse.node.ObjectNode;
 import com.cloudurable.jparse.node.RootNode;
+import com.cloudurable.jparse.parser.IndexOverlayParser;
+import com.cloudurable.jparse.parser.JsonParser;
 import com.cloudurable.jparse.source.Sources;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +30,7 @@ public class TestKeyLookUp {
     }
 
 
-    private RootNode getJsonRoot(Parser parser, String json1) {
+    private RootNode getJsonRoot(IndexOverlayParser parser, String json1) {
         return parser.parse(Sources.stringSource(json1.replace("'", "\"")));
     }
 }

--- a/src/test/java/com/cloudurable/jparse/node/support/ElementUtilTest.java
+++ b/src/test/java/com/cloudurable/jparse/node/support/ElementUtilTest.java
@@ -1,7 +1,7 @@
 package com.cloudurable.jparse.node.support;
 
-import com.cloudurable.jparse.JsonParser;
-import com.cloudurable.jparse.Parser;
+import com.cloudurable.jparse.parser.JsonParser;
+import com.cloudurable.jparse.parser.IndexOverlayParser;
 import com.cloudurable.jparse.node.NodeType;
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.source.Sources;
@@ -158,7 +158,7 @@ class ElementUtilTest {
     @Test
     void testObject() {
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................0123456789
         final String json = "{'a':'b'}";
         final TokenList list = (TokenList) parser.scan(Sources.stringSource(json.replace("'", "\"")));
@@ -174,7 +174,7 @@ class ElementUtilTest {
     @Test
     void testObject2() {
 
-        final Parser parser = new JsonParser();
+        final IndexOverlayParser parser = new JsonParser();
         //...................0123456789
         final String json = "{'a':'b'}";
         RootNode parse = parser.parse(niceJson(json));

--- a/src/test/java/com/cloudurable/jparse/source/SourcesEventTest.java
+++ b/src/test/java/com/cloudurable/jparse/source/SourcesEventTest.java
@@ -1,6 +1,6 @@
 package com.cloudurable.jparse.source;
 
-import com.cloudurable.jparse.parser.JsonParser;
+import com.cloudurable.jparse.parser.JsonEventParser;
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.support.PathUtils;
 import com.cloudurable.jparse.token.Token;
@@ -18,7 +18,7 @@ import static com.cloudurable.jparse.node.support.PathUtils.walkFull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SourcesTest {
+public class SourcesEventTest {
 
     final static String glossaryJson;
 
@@ -120,9 +120,8 @@ public class SourcesTest {
     private void doTest(CharSource charSource, File file) {
 
         try {
-            JsonParser jsonParser = new JsonParser();
-
-            RootNode jsonRoot = jsonParser.parse(charSource);
+            final var jsonParser = new JsonEventParser();
+            final var jsonRoot = jsonParser.parse(charSource);
 
             walkFull(jsonRoot.getNode());
             jsonRoot.getNode().rootElementToken();
@@ -132,7 +131,7 @@ public class SourcesTest {
     }
 
     private void doTest(CharSource charSource) {
-        JsonParser jsonParser = new JsonParser();
+        final var jsonParser = new JsonEventParser();
 
         RootNode jsonRoot = jsonParser.parse(charSource);
         Token token = jsonRoot.getNode().rootElementToken();


### PR DESCRIPTION
Wrote a STAX-style parser to compete against event-driven parsers. 

Noggit claims to be the world's fastest streaming JSON parser for Java and is used by SOLR.
Noggit has a streaming API which is a StAX/pull parser. I'd call it an event-driven parser. 

Oddly when testing against Noggit, I noticed that the JParse index overlay parser was faster than just walking the events with Noggit and not building a DOM. 

But what if you need an event parser? If JParse can do a functioning DOM using an index overlay faster than Noggit can walk the events, then if JParse adds an event-based parser, it should scream.


### Here is the benchmark code

```java

    //Read the glossary example from JSON dot org with the index overlay using JParse. 
    @Benchmark
    public void readGlossaryJParse(Blackhole bh) {
        bh.consume(new JsonParser().parse(glossaryJsonData));
    }

    //Read the glossary example from JSON dot org while building an index overlay using JParse in event-driven mode. 
    @Benchmark
    public void readGlossaryJParseWithEvents(Blackhole bh) {
        bh.consume(new JsonEventParser().parse(glossaryJsonData));
    }

    //Read the glossary example from JSON dot org with Noggit and just listen to events. 
    @Benchmark
    public void readGlossaryNoggitEvent(Blackhole bh) throws Exception {

        final var jsonParser =  new JSONParser(glossaryJsonData);

        int event = -1;
        while (event!=JSONParser.EOF) {
            event = jsonParser.nextEvent();
        }

        bh.consume(event);
    }


    //Read the glossary example from JSON dot org with JParse and just listen to events. 
    @Benchmark
    public void readGlossaryEventJParse(Blackhole bh) throws Exception {

        final var jsonParser =  new JsonEventParser();
        final int [] token = new int[1];
        final var events = new TokenEventListener() {
            @Override
            public void start(int tokenId, int index, CharSource source) {
                token[0] = tokenId;
            }

            @Override
            public void end(int tokenId, int index, CharSource source) {
                token[0] = tokenId;
            }
        };

        jsonParser.parse(glossaryJsonData, events);

        bh.consume(token);
    }

    //Build a useable DOM with Noggit
    @Benchmark
    public void readWebGlossaryNoggitObjectBuilder(Blackhole bh) throws Exception {

        bh.consume(ObjectBuilder.fromJSON(glossaryJsonData));
    }
```


## Results comparing Noggit Event Driven to JParse event-driven and JParse index overlay.

```text 

Benchmark                                      Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryEventJParse             thrpt    2  1510822.955          ops/s
BenchMark.readGlossaryJParse                  thrpt    2   996041.462          ops/s
BenchMark.readGlossaryNoggitEvent             thrpt    2   960327.894          ops/s

```

As stated, the JParse index overlay parser, which builds a usable DOM, is faster than Noggit just walking the events and building nothing!
The JParse index event-driven parser is substantially faster than Noggit just walking the events and building nothing!
 

```text 
BenchMark.readGlossaryJParse                  thrpt    2   996041.462          ops/s
BenchMark.readGlossaryJParseWithEvents        thrpt    2   620481.661          ops/s
BenchMark.readWebGlossaryNoggitObjectBuilder  thrpt    2   530800.854          ops/s
```

The far more common use case will be using a DOM-style approach. 
The `BenchMark.readGlossaryJParseWithEvents` is included just for fun. You would always use the JParse index overlay to build a DOM. 
We build a DOM with the event parser to test it thoroughly and as an example of using the event-based approach. 

Both the JParse index overlays are faster than the equivalent DOM builder from Noggit. While the regular JParse index-overlay parser is substantially faster. 




