### PR TITLE
more validation for numbers. 

### DIFF
--- a/src/jmh/java/com/cloudurable/jparse/BenchMark.java
+++ b/src/jmh/java/com/cloudurable/jparse/BenchMark.java
@@ -176,58 +176,79 @@ public class BenchMark {
 //    public void readGlossaryJackson(Blackhole bh) throws JsonProcessingException {
 //        bh.consume(mapper.readValue(glossaryJsonData, mapTypeRef));
 //    }
+//
+//    @Benchmark
+//    public void readGlossaryJParse(Blackhole bh) {
+//        bh.consume(new JsonParser().parse(glossaryJsonData));
+//    }
+//
+//    @Benchmark
+//    public void readGlossaryJParseWithEvents(Blackhole bh) {
+//        bh.consume(new JsonEventParser().parse(glossaryJsonData));
+//    }
 
+//    @Benchmark
+//    public void readGlossaryNoggitEvent(Blackhole bh) throws Exception {
+//
+//        final var jsonParser =  new JSONParser(glossaryJsonData);
+//
+//        int event = -1;
+//        while (event!=JSONParser.EOF) {
+//            event = jsonParser.nextEvent();
+//        }
+//
+//        bh.consume(event);
+//    }
+
+
+//    @Benchmark
+//    public void readGlossaryEventJParse(Blackhole bh) throws Exception {
+//
+//        final var jsonParser =  new JsonEventParser();
+//        final int [] token = new int[1];
+//        final var events = new TokenEventListener() {
+//            @Override
+//            public void start(int tokenId, int index, CharSource source) {
+//                token[0] = tokenId;
+//            }
+//
+//            @Override
+//            public void end(int tokenId, int index, CharSource source) {
+//                token[0] = tokenId;
+//            }
+//        };
+//
+//        jsonParser.parse(glossaryJsonData, events);
+//
+//        bh.consume(token);
+//    }
+
+
+//
+//    @Benchmark
+//    public void jParseFloatArray(Blackhole bh) {
+//        bh.consume(Json.toArrayNode(doublesJsonData).getFloatArray());
+//    }
+//
+//    @Benchmark
+//    public void jParseFloatArrayFast(Blackhole bh) {
+//        bh.consume(Json.toArrayNode(doublesJsonData).getFloatArrayFast());
+//    }
+//
     @Benchmark
-    public void readGlossaryJParse(Blackhole bh) {
-        bh.consume(new JsonParser().parse(glossaryJsonData));
+    public void jParseDoubleArray(Blackhole bh) {
+        bh.consume(Json.toArrayNode(doublesJsonData).getDoubleArray());
     }
 
     @Benchmark
-    public void readGlossaryJParseWithEvents(Blackhole bh) {
-        bh.consume(new JsonEventParser().parse(glossaryJsonData));
+    public void jParseDoubleArrayFast(Blackhole bh) {
+        bh.consume(Json.toArrayNode(doublesJsonData).getDoubleArrayFast());
     }
-
-    @Benchmark
-    public void readGlossaryNoggitEvent(Blackhole bh) throws Exception {
-
-        final var jsonParser =  new JSONParser(glossaryJsonData);
-
-        int event = -1;
-        while (event!=JSONParser.EOF) {
-            event = jsonParser.nextEvent();
-        }
-
-        bh.consume(event);
-    }
-
-
-    @Benchmark
-    public void readGlossaryEventJParse(Blackhole bh) throws Exception {
-
-        final var jsonParser =  new JsonEventParser();
-        final int [] token = new int[1];
-        final var events = new TokenEventListener() {
-            @Override
-            public void start(int tokenId, int index, CharSource source) {
-                token[0] = tokenId;
-            }
-
-            @Override
-            public void end(int tokenId, int index, CharSource source) {
-                token[0] = tokenId;
-            }
-        };
-
-        jsonParser.parse(glossaryJsonData, events);
-
-        bh.consume(token);
-    }
-
-    @Benchmark
-    public void readWebGlossaryNoggitObjectBuilder(Blackhole bh) throws Exception {
-
-        bh.consume(ObjectBuilder.fromJSON(glossaryJsonData));
-    }
+//    @Benchmark
+//    public void readWebGlossaryNoggitObjectBuilder(Blackhole bh) throws Exception {
+//
+//        bh.consume(ObjectBuilder.fromJSON(glossaryJsonData));
+//    }
 
 
 
@@ -307,15 +328,7 @@ public class BenchMark {
 //        bh.consume(mapper.readValue(intsJsonData, BigInteger[].class));
 //    }
 
-//    @Benchmark
-//    public void jParseFloatArray(Blackhole bh) {
-//        bh.consume(Json.toArrayNode(doublesJsonData).getFloatArray());
-//    }
-//
-//    @Benchmark
-//    public void jParseFloatArrayFast(Blackhole bh) {
-//        bh.consume(Json.toArrayNode(doublesJsonData).getFloatArrayFast());
-//    }
+
 //
 //
 //    @Benchmark
@@ -324,15 +337,7 @@ public class BenchMark {
 //    }
 
 //
-//    @Benchmark
-//    public void jParseDoubleArray(Blackhole bh) {
-//        bh.consume(Json.toArrayNode(doublesJsonData).getDoubleArray());
-//    }
-//
-//    @Benchmark
-//    public void jParseDoubleArrayFast(Blackhole bh) {
-//        bh.consume(Json.toArrayNode(doublesJsonData).getDoubleArrayFast());
-//    }
+
 //
 //
 //    @Benchmark

--- a/src/test/java/com/cloudurable/jparse/JsonParserTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonParserTest.java
@@ -534,6 +534,14 @@ class JsonParserTest {
     }
 
 
+
+    @Test
+    void y_object_empty_key() {
+        final var parser = new JsonParser();
+        final String json = "{\"\":0}";
+        final RootNode jsonRoot = parser.parse(niceJson(json));
+    }
+
     @Test
     void test3ItemMap() {
         final IndexOverlayParser parser = new JsonParser();

--- a/src/test/java/com/cloudurable/jparse/source/CharSourceNumberParse.java
+++ b/src/test/java/com/cloudurable/jparse/source/CharSourceNumberParse.java
@@ -1,0 +1,168 @@
+package com.cloudurable.jparse.source;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CharSourceNumberParse {
+
+
+    @Test
+    void parseMissingDecimalMantissa() {
+        //.....................01234
+        final String string = "9.e+ ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+
+    @Test
+    void parseMissingNumbersAfterExponent() {
+        //.....................01234
+        final String string = "1.0e+ ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+    @Test
+    void parseMissingNumbersAfterExponent4() {
+        //.....................01234
+        final String string = "0.3e+ ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+    @Test
+    void parseMissingDecimalMantissa2() {
+        //.....................01234
+        final String string = "2.e3";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+
+    @Test
+    void parseMissingNumbersAfterExponent2() {
+        //.....................01234
+        final String string = "1.0e- ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+    @Test
+    void parseMissingNumbersAfterExponent3() {
+        //.....................01234
+        final String string = "2.e-3 ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+
+    @Test
+    void startsWith0() {
+        //.....................01234
+        final String string = "012 ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+    @Test
+    void startsWithPlus() {
+        //.....................01234
+        final String string = "+1 ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+
+    @Test
+    void bigExponentMissingNumber() {
+        //.....................01234
+        final String string = "0E+ ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+    /*
+     * PASS! ./src/test/resources/validation/n_number_neg_int_starting_with_zero.json
+     * [-012]
+     *
+     * PASS! ./src/test/resources/validation/n_number_minus_space_1.json
+     * [- 1]
+     * PASS! ./src/test/resources/validation/n_number_neg_real_without_int_part.json
+     * [-.123]
+     */
+
+    @Test
+    void negativeStartsWith0() {
+        //.....................01234
+        final String string = "-012 ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+    @Test
+    void cantBeJustAMinus() {
+        //.....................01234
+        final String string = "- 1 ";
+        final var charSource = Sources.stringSource(string);
+        charSource.next();
+        try {
+            charSource.findEndOfNumber();
+            assertTrue(false);
+        } catch (Exception ex) {
+        }
+    }
+
+}


### PR DESCRIPTION
After adding more compliant number scanning, there appears to be some additional performance degradation. Another round of perf tuning for number parsing is likely in order after. This should happen after final validation compliance. 


```
Passed Mandatory 95 Failed 0  (all have to pass)
Passed Optional 30 Failed 5  (optional testing, as many passing as possible) 
Passed Garbage 31 Failed 155  (all should fail)

Run 1


Benchmark                                      Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryEventJParse             thrpt    2  1407857.199          ops/s
BenchMark.readGlossaryJParse                  thrpt    2   992902.534          ops/s
BenchMark.readGlossaryJParseWithEvents        thrpt    2   607664.362          ops/s
BenchMark.readGlossaryNoggitEvent             thrpt    2   686736.202          ops/s
BenchMark.readWebGlossaryNoggitObjectBuilder  thrpt    2   433881.428          ops/s


Run 2

Benchmark                                Mode  Cnt        Score   Error  Units
BenchMark.jParseDoubleArray             thrpt    2   641799.242          ops/s
BenchMark.jParseDoubleArrayFast         thrpt    2   740498.123          ops/s
BenchMark.jParseFloatArray              thrpt    2   618410.088          ops/s
BenchMark.jParseFloatArrayFast          thrpt    2   766177.515          ops/s


BenchMark.readGlossaryEventJParse       thrpt    2  1226862.242          ops/s
BenchMark.readGlossaryJParse            thrpt    2   914684.691          ops/s
BenchMark.readGlossaryJParseWithEvents  thrpt    2   361403.716          ops/s


Run 3

Benchmark                                Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryEventJParse       thrpt    2  1452049.426          ops/s
BenchMark.readGlossaryJParse            thrpt    2   934443.254          ops/s
BenchMark.readGlossaryJParseWithEvents  thrpt    2   603105.953          ops/s

Run 4

Benchmark                      Mode  Cnt       Score   Error  Units
BenchMark.readGlossaryJParse  thrpt    2  984819.588          ops/s


Run 5

Benchmark                         Mode  Cnt       Score   Error  Units
BenchMark.jParseDoubleArray      thrpt    2  738371.820          ops/s
BenchMark.jParseDoubleArrayFast  thrpt    2  846980.984          ops/s

```


Current status of compliance testing. 

```
> Task :Validation.main()
FAIL! ./src/test/resources/validation/i_string_UTF-16LE_with_BOM.json
��[ " � " ] 

FAIL! ./src/test/resources/validation/i_string_utf16BE_no_BOM.json
 [ " � " ]

FAIL! ./src/test/resources/validation/i_string_utf16LE_no_BOM.json
[ " � " ] 

FAIL! ./src/test/resources/validation/i_structure_500_nested_arrays.json
[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]]

FAIL! ./src/test/resources/validation/i_structure_UTF-8_BOM_empty_object.json
﻿{}

PASS! ./src/test/resources/validation/n_string_escape_x.json
["\x00"]

PASS! ./src/test/resources/validation/n_string_invalid_unicode_escape.json
["\uqqqq"]

PASS! ./src/test/resources/validation/n_string_incomplete_surrogate.json
["\uD834\uDd"]

PASS! ./src/test/resources/validation/n_array_items_separated_by_semicolon.json
[1:2]

PASS! ./src/test/resources/validation/n_string_with_trailing_garbage.json
""x

PASS! ./src/test/resources/validation/n_object_trailing_comma.json
{"id":0,}

PASS! ./src/test/resources/validation/n_string_invalid_utf8_after_escape.json
["\�"]

PASS! ./src/test/resources/validation/n_array_number_and_comma.json
[1,]

PASS! ./src/test/resources/validation/n_object_lone_continuation_byte_in_key_and_trailing_comma.json
{"�":"0",}

PASS! ./src/test/resources/validation/n_string_unicode_CapitalU.json
"\UA66D"

PASS! ./src/test/resources/validation/n_array_extra_comma.json
["",]

PASS! ./src/test/resources/validation/n_array_1_true_without_comma.json
[1 true]

PASS! ./src/test/resources/validation/n_structure_close_unopened_array.json
1]

PASS! ./src/test/resources/validation/n_string_incomplete_surrogate_escape_invalid.json
["\uD800\uD800\x"]

PASS! ./src/test/resources/validation/n_array_colon_instead_of_comma.json
["": 1]

PASS! ./src/test/resources/validation/n_object_trailing_comment_slash_open_incomplete.json
{"a":"b"}/

PASS! ./src/test/resources/validation/n_structure_array_trailing_garbage.json
[1]x

PASS! ./src/test/resources/validation/n_structure_object_followed_by_closing_object.json
{}}

PASS! ./src/test/resources/validation/n_string_1_surrogate_then_escape_u.json
["\uD800\u"]

PASS! ./src/test/resources/validation/n_string_1_surrogate_then_escape_u1.json
["\uD800\u1"]

PASS! ./src/test/resources/validation/n_object_with_trailing_garbage.json
{"a":"b"}#

PASS! ./src/test/resources/validation/n_string_1_surrogate_then_escape_u1x.json
["\uD800\u1x"]

PASS! ./src/test/resources/validation/n_structure_array_with_extra_array_close.json
[1]]

PASS! ./src/test/resources/validation/n_number_neg_real_without_int_part.json
[-.123]

PASS! ./src/test/resources/validation/n_number_1_000.json
[1 000.0]

PASS! ./src/test/resources/validation/n_string_incomplete_escaped_character.json
["\u00A"]

PASS! ./src/test/resources/validation/n_string_invalid_backslash_esc.json
["\a"]

PASS! ./src/test/resources/validation/n_string_escaped_emoji.json
["\🌀"]

PASS! ./src/test/resources/validation/n_array_comma_after_close.json
[""],

PASS! ./src/test/resources/validation/n_array_extra_close.json
["x"]]

PASS! ./src/test/resources/validation/n_string_invalid-utf-8-in-escape.json
["\u�"]
```