### PR TITLE
Encoding improvements 

### DIFF
--- a/src/jmh/java/com/cloudurable/jparse/BenchMark.java
+++ b/src/jmh/java/com/cloudurable/jparse/BenchMark.java
@@ -5,6 +5,7 @@ import com.cloudurable.jparse.parser.JsonParser;
 import com.cloudurable.jparse.source.CharSource;
 import com.cloudurable.jparse.source.Sources;
 import com.cloudurable.jparse.token.TokenEventListener;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -172,56 +173,56 @@ public class BenchMark {
 //        bh.consume(mapper.readValue(webXmlJsonData, mapTypeRef));
 //    }
 
-//    @Benchmark
-//    public void readGlossaryJackson(Blackhole bh) throws JsonProcessingException {
-//        bh.consume(mapper.readValue(glossaryJsonData, mapTypeRef));
-//    }
-//
-//    @Benchmark
-//    public void readGlossaryJParse(Blackhole bh) {
-//        bh.consume(new JsonParser().parse(glossaryJsonData));
-//    }
-//
-//    @Benchmark
-//    public void readGlossaryJParseWithEvents(Blackhole bh) {
-//        bh.consume(new JsonEventParser().parse(glossaryJsonData));
-//    }
+    @Benchmark
+    public void readGlossaryJackson(Blackhole bh) throws JsonProcessingException {
+        bh.consume(mapper.readValue(glossaryJsonData, mapTypeRef));
+    }
 
-//    @Benchmark
-//    public void readGlossaryNoggitEvent(Blackhole bh) throws Exception {
-//
-//        final var jsonParser =  new JSONParser(glossaryJsonData);
-//
-//        int event = -1;
-//        while (event!=JSONParser.EOF) {
-//            event = jsonParser.nextEvent();
-//        }
-//
-//        bh.consume(event);
-//    }
+    @Benchmark
+    public void readGlossaryJParse(Blackhole bh) {
+        bh.consume(new JsonParser().parse(glossaryJsonData));
+    }
 
-//
-//    @Benchmark
-//    public void readGlossaryEventJParse(Blackhole bh) throws Exception {
-//
-//        final var jsonParser =  new JsonEventParser();
-//        final int [] token = new int[1];
-//        final var events = new TokenEventListener() {
-//            @Override
-//            public void start(int tokenId, int index, CharSource source) {
-//                token[0] = tokenId;
-//            }
-//
-//            @Override
-//            public void end(int tokenId, int index, CharSource source) {
-//                token[0] = tokenId;
-//            }
-//        };
-//
-//        jsonParser.parse(glossaryJsonData, events);
-//
-//        bh.consume(token);
-//    }
+    @Benchmark
+    public void readGlossaryJParseWithEvents(Blackhole bh) {
+        bh.consume(new JsonEventParser().parse(glossaryJsonData));
+    }
+
+    @Benchmark
+    public void readGlossaryNoggitEvent(Blackhole bh) throws Exception {
+
+        final var jsonParser =  new JSONParser(glossaryJsonData);
+
+        int event = -1;
+        while (event!=JSONParser.EOF) {
+            event = jsonParser.nextEvent();
+        }
+
+        bh.consume(event);
+    }
+
+
+    @Benchmark
+    public void readGlossaryEventJParse(Blackhole bh) throws Exception {
+
+        final var jsonParser =  new JsonEventParser();
+        final int [] token = new int[1];
+        final var events = new TokenEventListener() {
+            @Override
+            public void start(int tokenId, int index, CharSource source) {
+                token[0] = tokenId;
+            }
+
+            @Override
+            public void end(int tokenId, int index, CharSource source) {
+                token[0] = tokenId;
+            }
+        };
+
+        jsonParser.parse(glossaryJsonData, events);
+
+        bh.consume(token);
+    }
 
 
 //
@@ -235,15 +236,15 @@ public class BenchMark {
 //        bh.consume(Json.toArrayNode(doublesJsonData).getFloatArrayFast());
 //    }
 
-    @Benchmark
-    public void jParseDoubleArray(Blackhole bh) {
-        bh.consume(Json.toArrayNode(doublesJsonData).getDoubleArray());
-    }
-
-    @Benchmark
-    public void jParseDoubleArrayFast(Blackhole bh) {
-        bh.consume(Json.toArrayNode(doublesJsonData).getDoubleArrayFast());
-    }
+//    @Benchmark
+//    public void jParseDoubleArray(Blackhole bh) {
+//        bh.consume(Json.toArrayNode(doublesJsonData).getDoubleArray());
+//    }
+//
+//    @Benchmark
+//    public void jParseDoubleArrayFast(Blackhole bh) {
+//        bh.consume(Json.toArrayNode(doublesJsonData).getDoubleArrayFast());
+//    }
 //    @Benchmark
 //    public void readWebGlossaryNoggitObjectBuilder(Blackhole bh) throws Exception {
 //

--- a/src/main/java/com/cloudurable/jparse/source/CharArrayCharSource.java
+++ b/src/main/java/com/cloudurable/jparse/source/CharArrayCharSource.java
@@ -242,6 +242,85 @@ public class CharArrayCharSource implements CharSource, ParseConstants {
     public String toString() {
         return new String(data);
     }
+//
+//    @Override
+//    public int findEndOfEncodedString() {
+//        int i = ++index;
+//        final var data = this.data;
+//        final var length = data.length;
+//        char ch = 0;
+//        boolean controlChar = false;
+//        for (; i < length; i++) {
+//            ch = data[i];
+//            switch (ch) {
+//                case CONTROL_ESCAPE_TOKEN:
+//                    controlChar = !controlChar;
+//                    continue;
+//                case STRING_END_TOKEN:
+//                    if (!controlChar) {
+//                        index = i + 1;
+//                        return i;
+//                    }
+//                    controlChar = false;
+//                    break;
+//                case 'u':
+//                    if (controlChar) {
+//                        i = findEndOfHexEncoding(i);
+//                        controlChar = false;
+//                    }
+//                    continue;
+//
+//                default:
+//                    if (controlChar) {
+//                        switch (ch) {
+//                            case 'n':
+//                            case 'b':
+//                            case '/':
+//                            case 'r':
+//                            case 't':
+//                                controlChar = false;
+//                            default:
+//                                if (ch >= SPACE_WS) {
+//                                    continue;
+//                                }
+//                                throw new UnexpectedCharacterException("Parsing JSON String", "Unexpected character while finding closing for String", this,  ch, i);
+//
+//                        }
+//                    }
+//            }
+//        }
+//        throw new UnexpectedCharacterException("Parsing JSON Encoded String", "Unable to find closing for String", this, (int) ch, i);
+//    }
+
+
+    private int findEndOfStringControlEncode(int i) {
+        final var data = this.data;
+        final var length = data.length;
+        char ch = 0;
+
+        for (; i < length; i++) {
+            ch = data[i];
+            switch (ch) {
+                case CONTROL_ESCAPE_TOKEN:
+                case STRING_END_TOKEN:
+                case 'n':
+                case 'b':
+                case '/':
+                case 'r':
+                case 't':
+                case 'f':
+                    return i;
+
+                case 'u':
+                    return findEndOfHexEncoding(i);
+
+                default:
+                    throw new UnexpectedCharacterException("Parsing JSON String", "Unexpected character while finding closing for String", this, ch, i);
+
+            }
+        }
+        throw new UnexpectedCharacterException("Parsing JSON Encoded String", "Unable to find closing for String", this, (int) ch, i);
+    }
 
     @Override
     public int findEndOfEncodedString() {
@@ -249,48 +328,27 @@ public class CharArrayCharSource implements CharSource, ParseConstants {
         final var data = this.data;
         final var length = data.length;
         char ch = 0;
-        boolean controlChar = false;
         for (; i < length; i++) {
             ch = data[i];
             switch (ch) {
                 case CONTROL_ESCAPE_TOKEN:
-                    controlChar = !controlChar;
+                    i = findEndOfStringControlEncode(i + 1);
                     continue;
                 case STRING_END_TOKEN:
-                    if (!controlChar) {
-                        index = i + 1;
-                        return i;
-                    }
-                    controlChar = false;
-                    break;
-                case 'u':
-                    if (controlChar) {
-                        i = findEndOfHexEncoding(i);
-                        controlChar = false;
-                    }
-                    continue;
-
+                    index = i +1;
+                    return i;
                 default:
-                    if (controlChar) {
-                        switch (ch) {
-                            case 'n':
-                            case 'b':
-                            case '/':
-                            case 'r':
-                            case 't':
-                                controlChar = false;
-                            default:
-                                if (ch >= SPACE_WS) {
-                                    continue;
-                                }
-                                throw new UnexpectedCharacterException("Parsing JSON String", "Unexpected character while finding closing for String", this,  ch, i);
-
-                        }
+                    if (ch >= SPACE_WS) {
+                        continue;
                     }
+                    throw new UnexpectedCharacterException("Parsing JSON String", "Unexpected character while finding closing for String", this,  ch, i);
+
             }
         }
+
         throw new UnexpectedCharacterException("Parsing JSON Encoded String", "Unable to find closing for String", this, (int) ch, i);
     }
+
 
     private int findEndOfHexEncoding(int index) {
         final var data = this.data;

--- a/src/test/java/com/cloudurable/jparse/JsonScannerTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonScannerTest.java
@@ -646,14 +646,15 @@ class JsonScannerTest {
     @Test
     void testSimpleString() {
         final IndexOverlayParser parser = new JsonParser();
-        final String str = "h";
-        final String json = String.format("\"%s\"", str);
-        final List<Token> tokens = parser.scan(Sources.stringSource(json));
+        //...................0123
+        final String json = "'h'";
+
+        final List<Token> tokens = parser.scan(Json.niceJson(json));
         assertEquals(1, tokens.size());
         final Token token = tokens.get(0);
         assertEquals(1, token.startIndex);
         assertEquals(2, token.endIndex);
-        assertEquals(str, json.substring(token.startIndex, token.endIndex));
+        assertEquals("h", json.substring(token.startIndex, token.endIndex));
     }
 
     @Test

--- a/src/test/java/com/cloudurable/jparse/JsonScannerTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonScannerTest.java
@@ -985,12 +985,179 @@ class JsonScannerTest {
     @Test
     void encoding() {
         final IndexOverlayParser parser = new JsonParser();
-
-        final String json = "'`u0003'";
+        //...................012345678
+        final String json = "'`u0004'";
         final List<Token> tokens = parser.scan(Json.niceJson(json));
 
         assertEquals(TokenTypes.STRING_TOKEN, tokens.get(0).type);
 
+    }
 
+    @Test
+    void badEncoding1() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................012345678
+        final String json = "['`x00']";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding2() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................012345678
+        final String json = "['`uqqqq']";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding3() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................012345678
+        final String json = "[`uD834`uDd']";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding4() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................012345678
+        final String json = "['`�']";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding5() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................012345678
+        final String json = "'`UA66D'";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding6() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................012345678
+        final String json = "'`uD800`uD800`x'";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding7() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................012345678
+        final String json = "'`uD800`u'";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding8() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................01234567890
+        final String json = "'`uD800`u1'";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding9() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................01234567890
+        final String json = "'`uD800`u1x'";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding10() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................01234567890
+        final String json = "'`u00A'";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding11() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................01234567890
+        final String json = "'`u\uD83C\uDF00'";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    void badEncoding12() {
+        final IndexOverlayParser parser = new JsonParser();
+        //...................012345678
+        final String json = "['`u�']";
+
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
+
+        }
     }
 }

--- a/src/test/java/com/cloudurable/jparse/JsonValidationTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonValidationTest.java
@@ -116,8 +116,20 @@ class JsonValidationTest {
         final IndexOverlayParser parser = new JsonParser();
 
         final String json = "['a\u0000a']";
-        final List<Token> tokens = parser.scan(Json.niceJson(json));
+        try {
+            final List<Token> tokens = parser.scan(Json.niceJson(json));
+            assertTrue(false);
+        } catch (Exception ex) {
 
+        }
+    }
+
+    @Test
+    void allowedEscapes() {
+        final IndexOverlayParser parser = new JsonParser();
+        final String json =   "['```/`'`b`f`n`r`t``']";
+        final var root = parser.parse(Json.niceJson(json));
+        assertEquals("\\/\"\b\f\n\r\t\\", root.asArray().get(0).asScalar().toString());
     }
 
     @Test

--- a/src/test/java/com/cloudurable/jparse/JsonValidationTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonValidationTest.java
@@ -116,12 +116,7 @@ class JsonValidationTest {
         final IndexOverlayParser parser = new JsonParser();
 
         final String json = "['a\u0000a']";
-        try {
-            final List<Token> tokens = parser.scan(Json.niceJson(json));
-            assertTrue(false);
-        } catch (Exception ex) {
-
-        }
+        final List<Token> tokens = parser.scan(Json.niceJson(json));
 
     }
 

--- a/src/test/java/com/cloudurable/jparse/source/CharArrayCharSourceTest.java
+++ b/src/test/java/com/cloudurable/jparse/source/CharArrayCharSourceTest.java
@@ -54,7 +54,7 @@ class CharArrayCharSourceTest {
     @Test
     void encoding2() {
         final IndexOverlayParser parser = new JsonParser();
-        //.................0123456789
+        //.................0123456789012
         final var  json = "'abc`n`u0003'";
         final var source = Sources.stringSource(Json.niceJson(json));
         source.next();


### PR DESCRIPTION

https://github.com/RichardHightower/jparse/issues/7

```
Passed Mandatory 95 Failed 0 
Passed Optional 30 Failed 5 
Passed Garbage 0 Failed 186 

Benchmark                         Mode  Cnt       Score   Error  Units
BenchMark.jParseDoubleArray      thrpt    2  703692.944          ops/s
BenchMark.jParseDoubleArrayFast  thrpt    2  810713.091          ops/s

Benchmark                                Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryEventJParse       thrpt    2  1227401.106          ops/s
BenchMark.readGlossaryJParse            thrpt    2   749776.588          ops/s
BenchMark.readGlossaryJParseWithEvents  thrpt    2   539304.451          ops/s
BenchMark.readGlossaryJackson           thrpt    2   435413.338          ops/s
BenchMark.readGlossaryNoggitEvent       thrpt    2   737795.600          ops/s
```

The laptop is running a bit slower but there have been some performance degradation with added validation as expected. 