### PR TITLE
Java11

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Whether you're processing massive data sets, building complex data pipelines, or
 more efficient way to parse JSON data, our index overlay JSON parser is the ideal solution.
 Try it today and experience the power of real-time JSON parsing for yourself!
 
-## What is an Index overlay parser
+## What is an Index overlay parser?
 
 An index overlay parser is a type of parser used for processing structured data, particularly JSON data. 
 Unlike traditional parsers that typically parse the entire data document before returning the results, 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,13 +11,13 @@ repositories {
 }
 
 dependencies {
+    testImplementation("com.jsoniter:jsoniter:0.9.23")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testImplementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
     testImplementation("com.jayway.jsonpath:json-path:2.4.0")
     testImplementation("org.noggit:noggit:0.8")
     testImplementation("io.nats:jnats:2.16.8")
-
 
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,3 +37,9 @@ jmh {
     iterations.set(2)
     fork.set(1)
 }
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}

--- a/src/jmh/java/com/cloudurable/jparse/BenchMark.java
+++ b/src/jmh/java/com/cloudurable/jparse/BenchMark.java
@@ -17,15 +17,12 @@ package com.cloudurable.jparse;
 
 import com.cloudurable.jparse.parser.JsonEventParser;
 import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
-import com.cloudurable.jparse.parser.JsonStrictParser;
-import com.cloudurable.jparse.source.CharSource;
 import com.cloudurable.jparse.source.Sources;
-import com.cloudurable.jparse.token.TokenEventListener;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jsoniter.JsonIterator;
-import io.nats.client.support.JsonParseException;
+import com.jsoniter.spi.TypeLiteral;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
@@ -36,6 +33,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @State(value = Scope.Benchmark)
 public class BenchMark {
@@ -61,6 +59,9 @@ public class BenchMark {
             = new TypeReference<>() {
     };
 
+    final static TypeLiteral<Map<String, Object>> mapTypeRefJI = new TypeLiteral<>() {
+
+    };
 
     final static TypeReference<List<Object>> listObjects
             = new TypeReference<>() {
@@ -108,8 +109,6 @@ public class BenchMark {
     }
 
     public static void main(String... args) throws Exception {
-
-
 
 
         try {
@@ -191,23 +190,54 @@ public class BenchMark {
 //    }
 
 
+    @Benchmark
+    public void readWebJSONJParseFast(Blackhole bh) {
+        bh.consume(fastParser.parse(webXmlJsonData));
+    }
+    @Benchmark
+    public void readWebJSONJParseStrict(Blackhole bh) {
+        bh.consume(strictParser.parse(webXmlJsonData));
+    }
+
+    @Benchmark
+    public void readWebJsonJsonIter(Blackhole bh) throws Exception{
+        JsonIterator iter = JsonIterator.parse(webXmlJsonData);
+        bh.consume(iter);
+        bh.consume(iter.read(mapTypeRefJI));
+    }
+
+    @Benchmark
+    public void readWebJsonJackson(Blackhole bh) throws JsonProcessingException {
+        bh.consume(mapper.readValue(webXmlJsonData, mapTypeRef));
+    }
+        @Benchmark
+    public void readGlossaryJackson(Blackhole bh) throws JsonProcessingException {
+        bh.consume(mapper.readValue(glossaryJsonData, mapTypeRef));
+    }
+
+    @Benchmark
+    public void readGlossaryJParseFast(Blackhole bh) {
+        bh.consume(fastParser.parse(glossaryJsonData));
+    }
+
+    @Benchmark
+    public void readGlossaryJParseStrict(Blackhole bh) {
+        bh.consume(strictParser.parse(glossaryJsonData));
+    }
+
+    @Benchmark
+    public void readGlossaryJsonIter(Blackhole bh) throws Exception{
+        JsonIterator iter = JsonIterator.parse(glossaryJsonData);
+        bh.consume(iter.read(mapTypeRefJI));
+    }
+
 //    @Benchmark
-//    public void readWebJSONJParse(Blackhole bh) {
-//        bh.consume(Json.toRootNode(webXmlJsonData));
+//    public void readGlossaryJackson(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(glossaryJsonData, mapTypeRef));
 //    }
 
+    //mapTypeRef
 
-//    @Benchmark
-//    public void readWebJSONJParseFast(Blackhole bh) {
-//        bh.consume(Json.builder().setStrict(false).build().parse(webXmlJsonData));
-//    }
-
-//
-//    @Benchmark
-//    public void readGlossaryFastJParse(Blackhole bh) {
-//        bh.consume(fastParser.parse(glossaryJsonData));
-//    }
-//
 //    @Benchmark
 //    public void readGlossaryStrictJParse(Blackhole bh) {
 //        bh.consume(strictParser.parse(glossaryJsonData));
@@ -351,21 +381,21 @@ public class BenchMark {
 //        bh.consume(this.strictParser.parse(intsJsonData).asArray().getLongArray());
 //    }
 
-    @Benchmark
-    public void jParseFastLongArray(Blackhole bh) {
-        bh.consume(this.fastParser.parse(intsJsonData).asArray().getLongArray());
-    }
-
-
-    @Benchmark
-    public void jacksonLongArray(Blackhole bh) throws JsonProcessingException {
-        bh.consume(mapper.readValue(intsJsonData, long[].class));
-    }
-
-    @Benchmark
-    public void jsonIteratorLongArray(Blackhole bh) throws JsonProcessingException {
-        bh.consume(JsonIterator.deserialize(intsJsonData, long[].class));
-    }
+//    @Benchmark
+//    public void jParseFastLongArray(Blackhole bh) {
+//        bh.consume(this.fastParser.parse(intsJsonData).asArray().getLongArray());
+//    }
+//
+//
+//    @Benchmark
+//    public void jacksonLongArray(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(intsJsonData, long[].class));
+//    }
+//
+//    @Benchmark
+//    public void jsonIteratorLongArray(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(JsonIterator.deserialize(intsJsonData, long[].class));
+//    }
 
 
 

--- a/src/jmh/java/com/cloudurable/jparse/BenchMark.java
+++ b/src/jmh/java/com/cloudurable/jparse/BenchMark.java
@@ -24,6 +24,7 @@ import com.cloudurable.jparse.token.TokenEventListener;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jsoniter.JsonIterator;
 import io.nats.client.support.JsonParseException;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
@@ -344,11 +345,11 @@ public class BenchMark {
 //    }
 //
 
-
-    @Benchmark
-    public void jParseStrictLongArray(Blackhole bh) {
-        bh.consume(this.strictParser.parse(intsJsonData).asArray().getLongArray());
-    }
+//
+//    @Benchmark
+//    public void jParseStrictLongArray(Blackhole bh) {
+//        bh.consume(this.strictParser.parse(intsJsonData).asArray().getLongArray());
+//    }
 
     @Benchmark
     public void jParseFastLongArray(Blackhole bh) {
@@ -361,14 +362,19 @@ public class BenchMark {
         bh.consume(mapper.readValue(intsJsonData, long[].class));
     }
 
-
-
-
-
     @Benchmark
-    public void jParseStrictFloatArray(Blackhole bh) {
-        bh.consume(this.strictParser.parse(doublesJsonData).asArray().getFloatArray());
+    public void jsonIteratorLongArray(Blackhole bh) throws JsonProcessingException {
+        bh.consume(JsonIterator.deserialize(intsJsonData, long[].class));
     }
+
+
+
+
+
+//    @Benchmark
+//    public void jParseStrictFloatArray(Blackhole bh) {
+//        bh.consume(this.strictParser.parse(doublesJsonData).asArray().getFloatArray());
+//    }
 
 //    @Benchmark
 //    public void jParseStrictFloatArrayFast(Blackhole bh) {
@@ -380,24 +386,24 @@ public class BenchMark {
 //        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getFloatArrayFast());
 //    }
 
-    @Benchmark
-    public void jParseFastFloatArray(Blackhole bh) {
-        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getFloatArray());
-    }
-
-
-
-    @Benchmark
-    public void jacksonFloatArray(Blackhole bh) throws JsonProcessingException {
-        bh.consume(mapper.readValue(doublesJsonData, float[].class));
-    }
-
-
-
-    @Benchmark
-    public void jParseStrictDoubleArray(Blackhole bh) {
-        bh.consume(this.strictParser.parse(doublesJsonData).asArray().getDoubleArray());
-    }
+//    @Benchmark
+//    public void jParseFastFloatArray(Blackhole bh) {
+//        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getFloatArray());
+//    }
+//
+//
+//
+//    @Benchmark
+//    public void jacksonFloatArray(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(doublesJsonData, float[].class));
+//    }
+//
+//
+//
+//    @Benchmark
+//    public void jParseStrictDoubleArray(Blackhole bh) {
+//        bh.consume(this.strictParser.parse(doublesJsonData).asArray().getDoubleArray());
+//    }
 
 //    @Benchmark
 //    public void jParseStrictDoubleArrayFast(Blackhole bh) {
@@ -408,65 +414,65 @@ public class BenchMark {
 //    public void jParseFastDoubleArrayFast(Blackhole bh) {
 //        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getDoubleArrayFast());
 //    }
-
-    @Benchmark
-    public void jParseFastDoubleArray(Blackhole bh) {
-        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getDoubleArray());
-    }
-
-    @Benchmark
-    public void jacksonDoubleArray(Blackhole bh) throws JsonProcessingException {
-        bh.consume(mapper.readValue(doublesJsonData, double[].class));
-    }
-
-
-    @Benchmark
-    public void jParseStrictIntArray(Blackhole bh) {
-        bh.consume(this.strictParser.parse(intsJsonData).asArray().getIntArray());
-    }
-
-    @Benchmark
-    public void jParseFastIntArray(Blackhole bh) {
-        bh.consume(this.fastParser.parse(intsJsonData).asArray().getIntArray());
-    }
-
-
-
-    @Benchmark
-    public void jacksonIntArray(Blackhole bh) throws JsonProcessingException {
-        bh.consume(mapper.readValue(intsJsonData, int[].class));
-    }
-
-    @Benchmark
-    public void jParseStrictBigIntArray(Blackhole bh) {
-        bh.consume(this.strictParser.parse(intsJsonData).asArray().getBigIntegerArray());
-    }
-
-    @Benchmark
-    public void jParseFastBigIntArray(Blackhole bh) {
-        bh.consume(this.fastParser.parse(intsJsonData).asArray().getBigIntegerArray());
-    }
-
-    @Benchmark
-    public void jacksonBigIntArray(Blackhole bh) throws JsonProcessingException {
-        bh.consume(mapper.readValue(intsJsonData, BigInteger[].class));
-    }
-
-    @Benchmark
-    public void jParseStrictBigDecimalArray(Blackhole bh) {
-        bh.consume(strictParser.parse(doublesJsonData).asArray().getBigDecimalArray());
-    }
-
-    @Benchmark
-    public void jParseFastBigDecimalArray(Blackhole bh) {
-        bh.consume(fastParser.parse(doublesJsonData).asArray().getBigDecimalArray());
-    }
-
-
-    @Benchmark
-    public void jacksonBigDecimalArray(Blackhole bh) throws JsonProcessingException {
-        bh.consume(mapper.readValue(doublesJsonData, BigDecimal[].class));
-    }
+//
+//    @Benchmark
+//    public void jParseFastDoubleArray(Blackhole bh) {
+//        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getDoubleArray());
+//    }
+//
+//    @Benchmark
+//    public void jacksonDoubleArray(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(doublesJsonData, double[].class));
+//    }
+//
+//
+//    @Benchmark
+//    public void jParseStrictIntArray(Blackhole bh) {
+//        bh.consume(this.strictParser.parse(intsJsonData).asArray().getIntArray());
+//    }
+//
+//    @Benchmark
+//    public void jParseFastIntArray(Blackhole bh) {
+//        bh.consume(this.fastParser.parse(intsJsonData).asArray().getIntArray());
+//    }
+//
+//
+//
+//    @Benchmark
+//    public void jacksonIntArray(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(intsJsonData, int[].class));
+//    }
+//
+//    @Benchmark
+//    public void jParseStrictBigIntArray(Blackhole bh) {
+//        bh.consume(this.strictParser.parse(intsJsonData).asArray().getBigIntegerArray());
+//    }
+//
+//    @Benchmark
+//    public void jParseFastBigIntArray(Blackhole bh) {
+//        bh.consume(this.fastParser.parse(intsJsonData).asArray().getBigIntegerArray());
+//    }
+//
+//    @Benchmark
+//    public void jacksonBigIntArray(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(intsJsonData, BigInteger[].class));
+//    }
+//
+//    @Benchmark
+//    public void jParseStrictBigDecimalArray(Blackhole bh) {
+//        bh.consume(strictParser.parse(doublesJsonData).asArray().getBigDecimalArray());
+//    }
+//
+//    @Benchmark
+//    public void jParseFastBigDecimalArray(Blackhole bh) {
+//        bh.consume(fastParser.parse(doublesJsonData).asArray().getBigDecimalArray());
+//    }
+//
+//
+//    @Benchmark
+//    public void jacksonBigDecimalArray(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(doublesJsonData, BigDecimal[].class));
+//    }
 
 
 //

--- a/src/main/java/com/cloudurable/jparse/node/BooleanNode.java
+++ b/src/main/java/com/cloudurable/jparse/node/BooleanNode.java
@@ -87,22 +87,33 @@ public class BooleanNode implements ScalarNode {
     @Override
     public char charAt(int index) {
         if (value) {
-            return switch (index) {
-                case 0 -> 't';
-                case 1 -> 'r';
-                case 2 -> 'u';
-                case 3 -> 'e';
-                default -> throw new IllegalStateException();
-            };
+            switch (index) {
+                case 0:
+                    return 't';
+                case 1:
+                    return 'r';
+                case 2:
+                    return 'u';
+                case 3:
+                    return 'e';
+                default:
+                    throw new IllegalStateException();
+            }
         } else {
-            return switch (index) {
-                case 0 -> 'f';
-                case 1 -> 'a';
-                case 2 -> 'l';
-                case 3 -> 's';
-                case 4 -> 'e';
-                default -> throw new IllegalStateException();
-            };
+            switch (index) {
+                case 0:
+                    return 'f';
+                case 1:
+                    return 'a';
+                case 2:
+                    return 'l';
+                case 3:
+                    return 's';
+                case 4:
+                    return 'e';
+                default:
+                    throw new IllegalStateException();
+            }
         }
     }
 

--- a/src/main/java/com/cloudurable/jparse/node/NullNode.java
+++ b/src/main/java/com/cloudurable/jparse/node/NullNode.java
@@ -60,13 +60,17 @@ public class NullNode implements ScalarNode {
 
     @Override
     public char charAt(int index) {
-        return switch (index) {
-            case 0 -> 'n';
-            case 1 -> 'u';
-            case 2 -> 'l';
-            case 3 -> 'l';
-            default -> throw new IllegalStateException();
-        };
+        switch (index) {
+            case 0:
+                return 'n';
+            case 1:
+                return 'u';
+            case 2:
+            case 3:
+                return 'l';
+            default:
+                throw new IllegalStateException();
+        }
     }
 
     @Override

--- a/src/main/java/com/cloudurable/jparse/node/NumberNode.java
+++ b/src/main/java/com/cloudurable/jparse/node/NumberNode.java
@@ -141,17 +141,21 @@ public class NumberNode extends Number implements ScalarNode, CharSequence {
     }
 
     public boolean isInteger() {
-        return switch (elementType) {
-            case INT -> source.isInteger(this.token.startIndex, this.token.endIndex);
-            default -> false;
-        };
+        switch (elementType) {
+            case INT:
+                return source.isInteger(this.token.startIndex, this.token.endIndex);
+            default:
+                return false;
+        }
     }
 
     public boolean isLong() {
-        return switch (elementType) {
-            case INT -> !source.isInteger(this.token.startIndex, this.token.endIndex);
-            default -> false;
-        };
+        switch (elementType) {
+            case INT:
+                return !source.isInteger(this.token.startIndex, this.token.endIndex);
+            default:
+                return false;
+        }
     }
 
 

--- a/src/main/java/com/cloudurable/jparse/node/ObjectNode.java
+++ b/src/main/java/com/cloudurable/jparse/node/ObjectNode.java
@@ -149,7 +149,9 @@ public class ObjectNode extends AbstractMap<CharSequence, Node> implements Colle
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof final ObjectNode other)) return false;
+        if (!(o instanceof  ObjectNode)) return false;
+
+        final ObjectNode other = (ObjectNode) o;
 
         if (this.tokens.size() != other.tokens.size()) {
             return false;
@@ -324,13 +326,16 @@ public class ObjectNode extends AbstractMap<CharSequence, Node> implements Colle
             keys = new ArrayList<>(childrenTokens.size() / 2);
             for (int index = 0; index < childrenTokens.size(); index += 2) {
                 List<Token> itemKey = childrenTokens.get(index);
-                CharSequence element;
                 Token keyToken = itemKey.get(1);
-                element = switch (keyToken.type) {
-                    case TokenTypes.STRING_TOKEN -> new StringNode(keyToken, source, objectsKeysCanBeEncoded).toString();
-                    default -> throw new IllegalStateException("Only String are allowed for keys " + TokenTypes.getTypeName(keyToken.type));
+                switch (keyToken.type) {
+                    case TokenTypes.STRING_TOKEN :
+                        final var element  =new StringNode(keyToken, source, objectsKeysCanBeEncoded);
+                        keys.add(element);
+                        break;
+                    default :
+                        throw new IllegalStateException("Only String are allowed for keys " + TokenTypes.getTypeName(keyToken.type));
                 };
-                keys.add(element);
+
             }
         }
         return keys;

--- a/src/main/java/com/cloudurable/jparse/node/RootNode.java
+++ b/src/main/java/com/cloudurable/jparse/node/RootNode.java
@@ -53,20 +53,26 @@ public class RootNode implements CollectionNode {
 
     @Override
     public Node getNode(Object key) {
-        return switch (rootToken.type) {
-            case OBJECT_TOKEN -> getObjectNode().getNode(key);
-            case ARRAY_TOKEN -> getArrayNode().getNode(key);
-            default -> doGetNode(key);
-        };
+        switch (rootToken.type) {
+            case OBJECT_TOKEN:
+                return getObjectNode().getNode(key);
+            case ARRAY_TOKEN:
+                return getArrayNode().getNode(key);
+            default:
+                return doGetNode(key);
+        }
     }
 
     @Override
     public List<List<Token>> childrenTokens() {
-        return switch (rootToken.type) {
-            case OBJECT_TOKEN -> getObjectNode().childrenTokens();
-            case ARRAY_TOKEN -> getArrayNode().childrenTokens();
-            default -> doGetChildrenTokens();
-        };
+        switch (rootToken.type) {
+            case OBJECT_TOKEN:
+                return getObjectNode().childrenTokens();
+            case ARRAY_TOKEN:
+                return getArrayNode().childrenTokens();
+            default:
+                return doGetChildrenTokens();
+        }
     }
 
     private List<List<Token>> doGetChildrenTokens() {

--- a/src/main/java/com/cloudurable/jparse/node/support/NodeUtils.java
+++ b/src/main/java/com/cloudurable/jparse/node/support/NodeUtils.java
@@ -63,18 +63,28 @@ public class NodeUtils {
 
         final NodeType nodeType = NodeType.tokenTypeToElement(tokens.get(0).type);
 
-        return switch (nodeType) {
-            case ARRAY -> new ArrayNode((TokenSubList) tokens, source, objectsKeysCanBeEncoded);
-            case INT -> new NumberNode(tokens.get(0), source, NodeType.INT);
-            case FLOAT -> new NumberNode(tokens.get(0), source, NodeType.FLOAT);
-            case OBJECT -> new ObjectNode((TokenSubList) tokens, source, objectsKeysCanBeEncoded);
-            case STRING -> new StringNode(tokens.get(0), source);
-            case BOOLEAN -> new BooleanNode(tokens.get(0), source);
-            case NULL -> new NullNode(tokens.get(0), source);
-            case PATH_INDEX -> new IndexPathNode(tokens.get(0), source);
-            case PATH_KEY -> new KeyPathNode(tokens.get(0), source);
-            default -> throw new IllegalStateException();
-        };
+        switch (nodeType) {
+            case ARRAY:
+                return new ArrayNode((TokenSubList) tokens, source, objectsKeysCanBeEncoded);
+            case INT:
+                return new NumberNode(tokens.get(0), source, NodeType.INT);
+            case FLOAT:
+                return new NumberNode(tokens.get(0), source, NodeType.FLOAT);
+            case OBJECT:
+                return new ObjectNode((TokenSubList) tokens, source, objectsKeysCanBeEncoded);
+            case STRING:
+                return new StringNode(tokens.get(0), source);
+            case BOOLEAN:
+                return new BooleanNode(tokens.get(0), source);
+            case NULL:
+                return new NullNode(tokens.get(0), source);
+            case PATH_INDEX:
+                return new IndexPathNode(tokens.get(0), source);
+            case PATH_KEY:
+                return new KeyPathNode(tokens.get(0), source);
+            default:
+                throw new IllegalStateException();
+        }
     }
 
 
@@ -84,16 +94,24 @@ public class NodeUtils {
         final var tokens = theTokens.subList(1, theTokens.size());
         final NodeType nodeType = NodeType.tokenTypeToElement(rootToken.type);
 
-        return switch (nodeType) {
-            case ARRAY -> new ArrayNode((TokenSubList) tokens, source, objectsKeysCanBeEncoded);
-            case INT -> new NumberNode(tokens.get(0), source, NodeType.INT);
-            case FLOAT -> new NumberNode(tokens.get(0), source, NodeType.FLOAT);
-            case OBJECT -> new ObjectNode((TokenSubList) tokens, source, objectsKeysCanBeEncoded);
-            case STRING -> new StringNode(tokens.get(0), source);
-            case BOOLEAN -> new BooleanNode(tokens.get(0), source);
-            case NULL -> new NullNode(tokens.get(0), source);
-            default -> throw new IllegalStateException();
-        };
+        switch (nodeType) {
+            case ARRAY:
+                return new ArrayNode((TokenSubList) tokens, source, objectsKeysCanBeEncoded);
+            case INT:
+                return new NumberNode(tokens.get(0), source, NodeType.INT);
+            case FLOAT:
+                return new NumberNode(tokens.get(0), source, NodeType.FLOAT);
+            case OBJECT:
+                return new ObjectNode((TokenSubList) tokens, source, objectsKeysCanBeEncoded);
+            case STRING:
+                return new StringNode(tokens.get(0), source);
+            case BOOLEAN:
+                return new BooleanNode(tokens.get(0), source);
+            case NULL:
+                return new NullNode(tokens.get(0), source);
+            default:
+                throw new IllegalStateException();
+        }
     }
 
 

--- a/src/main/java/com/cloudurable/jparse/node/support/NumberParseResult.java
+++ b/src/main/java/com/cloudurable/jparse/node/support/NumberParseResult.java
@@ -15,5 +15,44 @@
  */
 package com.cloudurable.jparse.node.support;
 
-public record NumberParseResult(int endIndex, boolean wasFloat) {
+import java.util.Objects;
+
+public final class NumberParseResult {
+    private final int endIndex;
+    private final boolean wasFloat;
+
+    public NumberParseResult(int endIndex, boolean wasFloat) {
+        this.endIndex = endIndex;
+        this.wasFloat = wasFloat;
+    }
+
+    public int endIndex() {
+        return endIndex;
+    }
+
+    public boolean wasFloat() {
+        return wasFloat;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (NumberParseResult) obj;
+        return this.endIndex == that.endIndex &&
+                this.wasFloat == that.wasFloat;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(endIndex, wasFloat);
+    }
+
+    @Override
+    public String toString() {
+        return "NumberParseResult[" +
+                "endIndex=" + endIndex + ", " +
+                "wasFloat=" + wasFloat + ']';
+    }
+
 }

--- a/src/main/java/com/cloudurable/jparse/parser/JsonEventAbstractParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/JsonEventAbstractParser.java
@@ -64,19 +64,42 @@ public abstract class JsonEventAbstractParser implements JsonEventParser, JsonIn
         @Override
         public void start(final int tokenId, final int index, final CharSource source) {
 
-            final var listener = switch (tokenId) {
-                case TokenTypes.OBJECT_TOKEN -> new JsonEventStrictParser.ComplexListener(TokenTypes.OBJECT_TOKEN);
-                case TokenTypes.ARRAY_TOKEN -> new JsonEventStrictParser.ComplexListener(TokenTypes.ARRAY_TOKEN);
-                case TokenTypes.ARRAY_ITEM_TOKEN -> arrayItemListener;
-                case TokenTypes.ATTRIBUTE_KEY_TOKEN -> new JsonEventStrictParser.ComplexListener(TokenTypes.ATTRIBUTE_KEY_TOKEN);
-                case TokenTypes.ATTRIBUTE_VALUE_TOKEN -> new JsonEventStrictParser.ComplexListener(TokenTypes.ATTRIBUTE_VALUE_TOKEN);
-                case TokenTypes.STRING_TOKEN -> stringListener;
-                case TokenTypes.FLOAT_TOKEN -> floatListener;
-                case TokenTypes.INT_TOKEN -> intListener;
-                case TokenTypes.BOOLEAN_TOKEN -> booleanListener;
-                case TokenTypes.NULL_TOKEN -> nullListener;
-                default -> exceptionListener;
-            };
+            TokenEventListener listener;
+            switch (tokenId) {
+                case TokenTypes.OBJECT_TOKEN:
+                    listener = new JsonEventStrictParser.ComplexListener(TokenTypes.OBJECT_TOKEN);
+                    break;
+                case TokenTypes.ARRAY_TOKEN:
+                    listener = new JsonEventStrictParser.ComplexListener(TokenTypes.ARRAY_TOKEN);
+                    break;
+                case TokenTypes.ARRAY_ITEM_TOKEN:
+                    listener = arrayItemListener;
+                    break;
+                case TokenTypes.ATTRIBUTE_KEY_TOKEN:
+                    listener = new JsonEventStrictParser.ComplexListener(TokenTypes.ATTRIBUTE_KEY_TOKEN);
+                    break;
+                case TokenTypes.ATTRIBUTE_VALUE_TOKEN:
+                    listener = new JsonEventStrictParser.ComplexListener(TokenTypes.ATTRIBUTE_VALUE_TOKEN);
+                    break;
+                case TokenTypes.STRING_TOKEN:
+                    listener = stringListener;
+                    break;
+                case TokenTypes.FLOAT_TOKEN:
+                    listener = floatListener;
+                    break;
+                case TokenTypes.INT_TOKEN:
+                    listener = intListener;
+                    break;
+                case TokenTypes.BOOLEAN_TOKEN:
+                    listener = booleanListener;
+                    break;
+                case TokenTypes.NULL_TOKEN:
+                    listener = nullListener;
+                    break;
+                default:
+                    listener = exceptionListener;
+                    break;
+            }
 
             listener.start(tokenId, index, source);
             stackIndex++;

--- a/src/main/java/com/cloudurable/jparse/source/CharArrayCharSource.java
+++ b/src/main/java/com/cloudurable/jparse/source/CharArrayCharSource.java
@@ -519,31 +519,33 @@ public class CharArrayCharSource implements CharSource, ParseConstants {
     }
 
     private boolean isHex(char datum) {
-        return switch (datum) {
-            case 'A'-> true;
-            case 'B'-> true;
-            case 'C'-> true;
-            case 'D'-> true;
-            case 'E'-> true;
-            case 'F'-> true;
-            case 'a'-> true;
-            case 'b'-> true;
-            case 'c'-> true;
-            case 'd'-> true;
-            case 'e'-> true;
-            case 'f'-> true;
-            case '0'-> true;
-            case '1'-> true;
-            case '2'-> true;
-            case '3'-> true;
-            case '4'-> true;
-            case '5'-> true;
-            case '6'-> true;
-            case '7'-> true;
-            case '8'-> true;
-            case '9'-> true;
-            default -> false;
-        };
+        switch (datum) {
+            case 'A':
+            case 'B':
+            case 'C':
+            case 'D':
+            case 'E':
+            case 'F':
+            case 'a':
+            case 'b':
+            case 'c':
+            case 'd':
+            case 'e':
+            case 'f':
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override
@@ -728,10 +730,21 @@ public class CharArrayCharSource implements CharSource, ParseConstants {
     }
 
     private boolean isNumber(final char ch) {
-        return switch (ch) {
-            case NUM_0, NUM_1, NUM_2, NUM_3, NUM_4, NUM_5, NUM_6, NUM_7, NUM_8, NUM_9 -> true;
-            default -> false;
-        };
+        switch (ch) {
+            case NUM_0:
+            case NUM_1:
+            case NUM_2:
+            case NUM_3:
+            case NUM_4:
+            case NUM_5:
+            case NUM_6:
+            case NUM_7:
+            case NUM_8:
+            case NUM_9:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private NumberParseResult parseFloatWithExponent() {
@@ -789,17 +802,33 @@ public class CharArrayCharSource implements CharSource, ParseConstants {
     }
 
     private boolean isNumberOrSign(char ch) {
-        return switch (ch) {
-            case NUM_0, NUM_1, NUM_2, NUM_3, NUM_4, NUM_5, NUM_6, NUM_7, NUM_8, NUM_9, MINUS, PLUS -> true;
-            default -> false;
-        };
+        switch (ch) {
+            case NUM_0:
+            case NUM_1:
+            case NUM_2:
+            case NUM_3:
+            case NUM_4:
+            case NUM_5:
+            case NUM_6:
+            case NUM_7:
+            case NUM_8:
+            case NUM_9:
+            case MINUS:
+            case PLUS:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private boolean isSign(char ch) {
-        return switch (ch) {
-            case MINUS, PLUS -> true;
-            default -> false;
-        };
+        switch (ch) {
+            case MINUS:
+            case PLUS:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override

--- a/src/main/java/com/cloudurable/jparse/source/CharArrayOffsetCharSource.java
+++ b/src/main/java/com/cloudurable/jparse/source/CharArrayOffsetCharSource.java
@@ -518,31 +518,33 @@ public class CharArrayOffsetCharSource implements CharSource, ParseConstants {
     }
 
     private boolean isHex(char datum) {
-        return switch (datum) {
-            case 'A'-> true;
-            case 'B'-> true;
-            case 'C'-> true;
-            case 'D'-> true;
-            case 'E'-> true;
-            case 'F'-> true;
-            case 'a'-> true;
-            case 'b'-> true;
-            case 'c'-> true;
-            case 'd'-> true;
-            case 'e'-> true;
-            case 'f'-> true;
-            case '0'-> true;
-            case '1'-> true;
-            case '2'-> true;
-            case '3'-> true;
-            case '4'-> true;
-            case '5'-> true;
-            case '6'-> true;
-            case '7'-> true;
-            case '8'-> true;
-            case '9'-> true;
-            default -> false;
-        };
+        switch (datum) {
+            case 'A':
+            case 'B':
+            case 'C':
+            case 'D':
+            case 'E':
+            case 'F':
+            case 'a':
+            case 'b':
+            case 'c':
+            case 'd':
+            case 'e':
+            case 'f':
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override
@@ -728,10 +730,21 @@ public class CharArrayOffsetCharSource implements CharSource, ParseConstants {
     }
 
     private boolean isNumber(final char ch) {
-        return switch (ch) {
-            case NUM_0, NUM_1, NUM_2, NUM_3, NUM_4, NUM_5, NUM_6, NUM_7, NUM_8, NUM_9 -> true;
-            default -> false;
-        };
+        switch (ch) {
+            case NUM_0:
+            case NUM_1:
+            case NUM_2:
+            case NUM_3:
+            case NUM_4:
+            case NUM_5:
+            case NUM_6:
+            case NUM_7:
+            case NUM_8:
+            case NUM_9:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private NumberParseResult parseFloatWithExponent() {
@@ -792,17 +805,33 @@ public class CharArrayOffsetCharSource implements CharSource, ParseConstants {
     }
 
     private boolean isNumberOrSign(char ch) {
-        return switch (ch) {
-            case NUM_0, NUM_1, NUM_2, NUM_3, NUM_4, NUM_5, NUM_6, NUM_7, NUM_8, NUM_9, MINUS, PLUS -> true;
-            default -> false;
-        };
+        switch (ch) {
+            case NUM_0:
+            case NUM_1:
+            case NUM_2:
+            case NUM_3:
+            case NUM_4:
+            case NUM_5:
+            case NUM_6:
+            case NUM_7:
+            case NUM_8:
+            case NUM_9:
+            case MINUS:
+            case PLUS:
+                return true;
+            default:
+                return false;
+        }
     }
 
     private boolean isSign(char ch) {
-        return switch (ch) {
-            case MINUS, PLUS -> true;
-            default -> false;
-        };
+        switch (ch) {
+            case MINUS:
+            case PLUS:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override

--- a/src/main/java/com/cloudurable/jparse/token/TokenTypes.java
+++ b/src/main/java/com/cloudurable/jparse/token/TokenTypes.java
@@ -33,19 +33,29 @@ public interface TokenTypes {
     int PATH_INDEX_TOKEN = 11;
 
     static String getTypeName(final int tokenType) {
-        return switch (tokenType) {
-            case OBJECT_TOKEN -> "Object";
-            case ATTRIBUTE_KEY_TOKEN -> "Key";
-            case ATTRIBUTE_VALUE_TOKEN -> "Attribute Value";
-            case ARRAY_TOKEN -> "Array";
-            case ARRAY_ITEM_TOKEN -> "Array Item";
-            case INT_TOKEN -> "Integer";
-            case FLOAT_TOKEN -> "Float";
-            case STRING_TOKEN -> "String";
-            case BOOLEAN_TOKEN -> "Boolean";
-            case NULL_TOKEN -> "Null";
-            default -> "" + tokenType;
-
-        };
+        switch (tokenType) {
+            case OBJECT_TOKEN:
+                return "Object";
+            case ATTRIBUTE_KEY_TOKEN:
+                return "Key";
+            case ATTRIBUTE_VALUE_TOKEN:
+                return "Attribute Value";
+            case ARRAY_TOKEN:
+                return "Array";
+            case ARRAY_ITEM_TOKEN:
+                return "Array Item";
+            case INT_TOKEN:
+                return "Integer";
+            case FLOAT_TOKEN:
+                return "Float";
+            case STRING_TOKEN:
+                return "String";
+            case BOOLEAN_TOKEN:
+                return "Boolean";
+            case NULL_TOKEN:
+                return "Null";
+            default:
+                return "" + tokenType;
+        }
     }
 }

--- a/src/test/java/com/cloudurable/jparse/Department.java
+++ b/src/test/java/com/cloudurable/jparse/Department.java
@@ -16,7 +16,38 @@
 package com.cloudurable.jparse;
 
 import java.util.List;
+import java.util.Objects;
 
-public record Department (String name,
-                          List<Employee> employees) {
+public final class Department {
+    private final String name;
+    private final List<Employee> employees;
+
+    public Department(String name,
+                List<Employee> employees) {
+        this.name = name;
+        this.employees = employees;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Department) obj;
+        return Objects.equals(this.name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, employees);
+    }
+
+    @Override
+    public String toString() {
+        return "Department[" +
+                "name=" + name + ']';
+    }
 }

--- a/src/test/java/com/cloudurable/jparse/Employee.java
+++ b/src/test/java/com/cloudurable/jparse/Employee.java
@@ -15,7 +15,78 @@
  */
 package com.cloudurable.jparse;
 
-public record Employee(String firstName, String lastName,
-                       String dob, boolean manager,
-                       int id, int managerId) {
+import java.util.Objects;
+
+public final class Employee {
+    private final String firstName;
+    private final String lastName;
+    private final String dob;
+    private final boolean manager;
+    private final int id;
+    private final int managerId;
+
+    public Employee(String firstName, String lastName,
+             String dob, boolean manager,
+             int id, int managerId) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.dob = dob;
+        this.manager = manager;
+        this.id = id;
+        this.managerId = managerId;
+    }
+
+    public String firstName() {
+        return firstName;
+    }
+
+    public String lastName() {
+        return lastName;
+    }
+
+    public String dob() {
+        return dob;
+    }
+
+    public boolean manager() {
+        return manager;
+    }
+
+    public int id() {
+        return id;
+    }
+
+    public int managerId() {
+        return managerId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Employee) obj;
+        return Objects.equals(this.firstName, that.firstName) &&
+                Objects.equals(this.lastName, that.lastName) &&
+                Objects.equals(this.dob, that.dob) &&
+                this.manager == that.manager &&
+                this.id == that.id &&
+                this.managerId == that.managerId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstName, lastName, dob, manager, id, managerId);
+    }
+
+    @Override
+    public String toString() {
+        return "Employee[" +
+                "firstName=" + firstName + ", " +
+                "lastName=" + lastName + ", " +
+                "dob=" + dob + ", " +
+                "manager=" + manager + ", " +
+                "id=" + id + ", " +
+                "managerId=" + managerId + ']';
+    }
+
 }

--- a/src/test/java/com/cloudurable/jparse/source/CharSourceNumberParse.java
+++ b/src/test/java/com/cloudurable/jparse/source/CharSourceNumberParse.java
@@ -17,10 +17,39 @@ package com.cloudurable.jparse.source;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CharSourceNumberParse {
 
+
+    @Test
+    void longUpperRange() {
+        String longMax = "" + Long.MAX_VALUE;
+        final var charSource = Sources.stringSource(longMax);
+        assertEquals(Long.MAX_VALUE, charSource.getLong(0, longMax.length()));
+    }
+
+    @Test
+    void longMinRange() {
+        String str = "" + Long.MIN_VALUE;
+        final var charSource = Sources.stringSource(str);
+        assertEquals(Long.MIN_VALUE, charSource.getLong(0, str.length()));
+    }
+
+    @Test
+    void intMaxRange() {
+        String str = "" + Integer.MAX_VALUE;
+        final var charSource = Sources.stringSource(str);
+        assertEquals(Integer.MAX_VALUE, charSource.getLong(0, str.length()));
+    }
+
+    @Test
+    void intMinRange() {
+        String str = "" + Integer.MIN_VALUE;
+        final var charSource = Sources.stringSource(str);
+        assertEquals(Integer.MIN_VALUE, charSource.getLong(0, str.length()));
+    }
 
     @Test
     void parseMissingDecimalMantissa() {


### PR DESCRIPTION
Backported to Java 11 to make it more compatible with other projects. 


# Perf Before backport to Java 11 (Java 17)
```
Benchmark                            Mode  Cnt       Score   Error  Units
BenchMark.readGlossaryJParseFast    thrpt    2  982192.155          ops/s
BenchMark.readGlossaryJParseStrict  thrpt    2  801173.785          ops/s
BenchMark.readGlossaryJackson       thrpt    2  455453.470          ops/s
BenchMark.readGlossaryJsonIter      thrpt    2  536640.889          ops/s
BenchMark.readWebJSONJParseFast     thrpt    2  224388.199          ops/s
BenchMark.readWebJSONJParseStrict   thrpt    2  209552.243          ops/s
BenchMark.readWebJsonJackson        thrpt    2  111813.350          ops/s
BenchMark.readWebJsonJsonIter       thrpt    2  121292.131          ops/s
```



## Perf After backport to Java 11 from Java 17
```
Benchmark                            Mode  Cnt       Score   Error  Units
BenchMark.readGlossaryJParseFast    thrpt    2  978629.406          ops/s
BenchMark.readGlossaryJParseStrict  thrpt    2  781784.753          ops/s
BenchMark.readGlossaryJackson       thrpt    2  463604.025          ops/s
BenchMark.readGlossaryJsonIter      thrpt    2  533071.555          ops/s
BenchMark.readWebJSONJParseFast     thrpt    2  220577.142          ops/s
BenchMark.readWebJSONJParseStrict   thrpt    2  208352.841          ops/s
BenchMark.readWebJsonJackson        thrpt    2  116528.133          ops/s
BenchMark.readWebJsonJsonIter       thrpt    2  114017.982          ops/s
```

If needed, we will probably eliminate `final var` to compile to Java 8. IDK. 
