### PR TITLE
added support extensions

### DIFF
--- a/src/jmh/java/com/cloudurable/jparse/BenchMark.java
+++ b/src/jmh/java/com/cloudurable/jparse/BenchMark.java
@@ -16,6 +16,7 @@
 package com.cloudurable.jparse;
 
 import com.cloudurable.jparse.parser.JsonEventParser;
+import com.cloudurable.jparse.parser.functable.JsonFuncParser;
 import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
 import com.cloudurable.jparse.source.Sources;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -30,7 +31,6 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.File;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +40,11 @@ public class BenchMark {
 
 
     JsonIndexOverlayParser fastParser = Json.builder().setStrict(false).build();
+
+    JsonIndexOverlayParser funcParser = Json.builder().setAllowComments(true)
+            .setObjectsKeysCanBeEncoded(false)
+            .setSupportNoQuoteKeys(false).build();
+
     JsonIndexOverlayParser strictParser = Json.builder().setStrict(true).build();
     JsonEventParser fastEventParser =  Json.builder().setStrict(false).buildEventParser();
     JsonEventParser strictEventParser =  Json.builder().setStrict(true).buildEventParser();
@@ -189,48 +194,57 @@ public class BenchMark {
 //        bh.consume(ObjectBuilder.fromJSON(jsonData));
 //    }
 
-
-    @Benchmark
-    public void readWebJSONJParseFast(Blackhole bh) {
-        bh.consume(fastParser.parse(webXmlJsonData));
-    }
-    @Benchmark
-    public void readWebJSONJParseStrict(Blackhole bh) {
-        bh.consume(strictParser.parse(webXmlJsonData));
-    }
-
-    @Benchmark
-    public void readWebJsonJsonIter(Blackhole bh) throws Exception{
-        JsonIterator iter = JsonIterator.parse(webXmlJsonData);
-        bh.consume(iter);
-        bh.consume(iter.read(mapTypeRefJI));
-    }
-
-    @Benchmark
-    public void readWebJsonJackson(Blackhole bh) throws JsonProcessingException {
-        bh.consume(mapper.readValue(webXmlJsonData, mapTypeRef));
-    }
-        @Benchmark
-    public void readGlossaryJackson(Blackhole bh) throws JsonProcessingException {
-        bh.consume(mapper.readValue(glossaryJsonData, mapTypeRef));
-    }
-
+//
+//    @Benchmark
+//    public void readWebJSONJParseFast(Blackhole bh) {
+//        bh.consume(fastParser.parse(webXmlJsonData));
+//    }
+//    @Benchmark
+//    public void readWebJSONJParseFunc(Blackhole bh) {
+//        bh.consume(funcParser.parse(webXmlJsonData));
+//    }
+//    @Benchmark
+//    public void readWebJSONJParseStrict(Blackhole bh) {
+//        bh.consume(strictParser.parse(webXmlJsonData));
+//    }
+//
+//    @Benchmark
+//    public void readWebJsonJsonIter(Blackhole bh) throws Exception{
+//        JsonIterator iter = JsonIterator.parse(webXmlJsonData);
+//        bh.consume(iter);
+//        bh.consume(iter.read(mapTypeRefJI));
+//    }
+//
+//    @Benchmark
+//    public void readWebJsonJackson(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(webXmlJsonData, mapTypeRef));
+//    }
+//        @Benchmark
+//    public void readGlossaryJackson(Blackhole bh) throws JsonProcessingException {
+//        bh.consume(mapper.readValue(glossaryJsonData, mapTypeRef));
+//    }
+//
     @Benchmark
     public void readGlossaryJParseFast(Blackhole bh) {
         bh.consume(fastParser.parse(glossaryJsonData));
     }
 
     @Benchmark
-    public void readGlossaryJParseStrict(Blackhole bh) {
-        bh.consume(strictParser.parse(glossaryJsonData));
+    public void readGlossaryJParseFunc(Blackhole bh) {
+        bh.consume(funcParser.parse(glossaryJsonData));
     }
-
-    @Benchmark
-    public void readGlossaryJsonIter(Blackhole bh) throws Exception{
-        JsonIterator iter = JsonIterator.parse(glossaryJsonData);
-        bh.consume(iter.read(mapTypeRefJI));
-    }
-
+//
+//    @Benchmark
+//    public void readGlossaryJParseStrict(Blackhole bh) {
+//        bh.consume(strictParser.parse(glossaryJsonData));
+//    }
+//
+//    @Benchmark
+//    public void readGlossaryJsonIter(Blackhole bh) throws Exception{
+//        JsonIterator iter = JsonIterator.parse(glossaryJsonData);
+//        bh.consume(iter.read(mapTypeRefJI));
+//    }
+//
 //    @Benchmark
 //    public void readGlossaryJackson(Blackhole bh) throws JsonProcessingException {
 //        bh.consume(mapper.readValue(glossaryJsonData, mapTypeRef));
@@ -375,16 +389,21 @@ public class BenchMark {
 //    }
 //
 
-//
+
 //    @Benchmark
 //    public void jParseStrictLongArray(Blackhole bh) {
 //        bh.consume(this.strictParser.parse(intsJsonData).asArray().getLongArray());
 //    }
 
-//    @Benchmark
-//    public void jParseFastLongArray(Blackhole bh) {
-//        bh.consume(this.fastParser.parse(intsJsonData).asArray().getLongArray());
-//    }
+    @Benchmark
+    public void jParseFuncLongArray(Blackhole bh) {
+        bh.consume(this.funcParser.parse(intsJsonData).asArray().getLongArray());
+    }
+
+    @Benchmark
+    public void jParseFastLongArray(Blackhole bh) {
+        bh.consume(this.fastParser.parse(intsJsonData).asArray().getLongArray());
+    }
 //
 //
 //    @Benchmark
@@ -396,7 +415,7 @@ public class BenchMark {
 //    public void jsonIteratorLongArray(Blackhole bh) throws JsonProcessingException {
 //        bh.consume(JsonIterator.deserialize(intsJsonData, long[].class));
 //    }
-
+//
 
 
 
@@ -406,20 +425,16 @@ public class BenchMark {
 //        bh.consume(this.strictParser.parse(doublesJsonData).asArray().getFloatArray());
 //    }
 
-//    @Benchmark
-//    public void jParseStrictFloatArrayFast(Blackhole bh) {
-//        bh.consume(this.strictParser.parse(doublesJsonData).asArray().getFloatArrayFast());
-//    }
 //
-//    @Benchmark
-//    public void jParseFastFloatArrayFast(Blackhole bh) {
-//        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getFloatArrayFast());
-//    }
+    @Benchmark
+    public void jParseFuncFloatArray(Blackhole bh) {
+        bh.consume(this.funcParser.parse(doublesJsonData).asArray().getFloatArray());
+    }
 
-//    @Benchmark
-//    public void jParseFastFloatArray(Blackhole bh) {
-//        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getFloatArray());
-//    }
+    @Benchmark
+    public void jParseFastFloatArray(Blackhole bh) {
+        bh.consume(this.fastParser.parse(doublesJsonData).asArray().getFloatArray());
+    }
 //
 //
 //
@@ -428,6 +443,12 @@ public class BenchMark {
 //        bh.consume(mapper.readValue(doublesJsonData, float[].class));
 //    }
 //
+//
+//    @Benchmark
+//    public void jsonIteratorFloatArray(Blackhole bh) {
+//        bh.consume(JsonIterator.deserialize(doublesJsonData, float[].class));
+//    }
+
 //
 //
 //    @Benchmark

--- a/src/main/java/com/cloudurable/jparse/parser/JsonParserBuilder.java
+++ b/src/main/java/com/cloudurable/jparse/parser/JsonParserBuilder.java
@@ -15,16 +15,109 @@
  */
 package com.cloudurable.jparse.parser;
 
+
+import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.parser.event.JsonEventFastParser;
+import com.cloudurable.jparse.parser.event.JsonEventStrictParser;
+import com.cloudurable.jparse.parser.functable.JsonFuncParser;
+import com.cloudurable.jparse.parser.functable.JsonParserFunctions;
+import com.cloudurable.jparse.parser.functable.ParseFunction;
+import com.cloudurable.jparse.parser.functable.ParsePartFunction;
+import com.cloudurable.jparse.parser.indexoverlay.JsonFastParser;
+import com.cloudurable.jparse.parser.indexoverlay.JsonStrictParser;
+import com.cloudurable.jparse.source.CharSource;
+import com.cloudurable.jparse.source.support.UnexpectedCharacterException;
 import com.cloudurable.jparse.token.TokenEventListener;
+
+import java.util.Arrays;
+
+import static com.cloudurable.jparse.node.support.ParseConstants.*;
 
 public class JsonParserBuilder {
 
     private TokenEventListener tokenEventListener;
     private boolean strict = false;
     private boolean objectsKeysCanBeEncoded;
+    private boolean allowHashComment;
+    private boolean allowSlashSlashComment;
+    private boolean allowSlashStarComment;
+    private ParseFunction[] funcTable;
+    private ParsePartFunction parseKey;
+    private  ParseFunction defaultFunc;
+    private boolean supportNoQuoteKeys;
+
 
     public static JsonParserBuilder builder() {
         return new JsonParserBuilder();
+    }
+
+
+    public boolean isSupportNoQuoteKeys() {
+        return supportNoQuoteKeys;
+    }
+
+    public JsonParserBuilder setSupportNoQuoteKeys(boolean supportNoQuoteKeys) {
+        this.supportNoQuoteKeys = supportNoQuoteKeys;
+        return this;
+    }
+
+    public ParseFunction getDefaultFunc() {
+        if (defaultFunc == null) {
+            this.defaultFunc = JsonParserFunctions.defaultFunc;
+        }
+        return defaultFunc;
+    }
+
+    public JsonParserBuilder setDefaultFunc(ParseFunction defaultFunc) {
+        this.defaultFunc = defaultFunc;
+        return this;
+    }
+
+    public ParseFunction[] getFuncTable() {
+        if (funcTable == null) {
+            funcTable = new ParseFunction[256];
+            Arrays.fill(funcTable, defaultFunc);
+        }
+        return funcTable;
+    }
+
+    public JsonParserBuilder setFuncTable(ParseFunction[] funcTable) {
+        this.funcTable = funcTable;
+        return this;
+    }
+
+    public JsonParserBuilder setAllowComments(boolean allowComments) {
+        this.allowHashComment = allowComments;
+        this.allowSlashSlashComment = allowComments;
+        this.allowSlashStarComment = allowComments;
+        return this;
+    }
+
+    public boolean isAllowHashComment() {
+        return allowHashComment;
+    }
+
+    public JsonParserBuilder setAllowHashComment(boolean allowHashComment) {
+        this.allowHashComment = allowHashComment;
+        return this;
+    }
+
+    public boolean isAllowSlashSlashComment() {
+        return allowSlashSlashComment;
+    }
+
+    public JsonParserBuilder setAllowSlashSlashComment(boolean allowSlashSlashComment) {
+        this.allowSlashSlashComment = allowSlashSlashComment;
+        return this;
+    }
+
+    public boolean isAllowSlashStarComment() {
+        return allowSlashStarComment;
+    }
+
+    public JsonParserBuilder setAllowSlashStarComment(boolean allowSlashStarComment) {
+        this.allowSlashStarComment = allowSlashStarComment;
+        return this;
     }
 
     public boolean objectsKeysCanBeEncoded() {
@@ -54,8 +147,59 @@ public class JsonParserBuilder {
         return this;
     }
 
+    public ParsePartFunction getParseKey() {
+        return parseKey;
+    }
+
+    public JsonParserBuilder setParseKey(ParsePartFunction parseKey) {
+        this.parseKey = parseKey;
+        return this;
+    }
+
     public JsonIndexOverlayParser build() {
-        if (strict()) {
+
+        if (isSupportNoQuoteKeys() || isAllowHashComment() || isAllowSlashSlashComment() || isAllowSlashStarComment() || getParseKey() != null) {
+            final var funcTable = this.getFuncTable();
+            funcTable[STRING_START_TOKEN] = JsonParserFunctions::parseString;
+            funcTable[NULL_START] = JsonParserFunctions::parseNull;
+            funcTable[TRUE_BOOLEAN_START] = JsonParserFunctions::parseTrue;
+            funcTable[FALSE_BOOLEAN_START] = JsonParserFunctions:: parseFalse;
+            for (int i = NUM_0; i < NUM_9 +1; i++){
+                funcTable[i] = JsonParserFunctions::parseNumber;
+            }
+            funcTable[MINUS] = JsonParserFunctions::parseNumber;
+            funcTable[PLUS] = JsonParserFunctions::parseNumber;
+
+            if (isAllowHashComment()) {
+                funcTable['#'] = (source, tokens) -> source.findChar('\n');
+            }
+
+            if (isSupportNoQuoteKeys() && getParseKey() == null ) {
+                setParseKey(JsonParserFunctions::parseKeyNoQuote);
+            }
+
+            if (isAllowSlashStarComment() || isAllowSlashSlashComment()) {
+                funcTable['/'] = (source, tokens) -> {
+                    int next = source.next();
+                    if (next == '/') {
+                        source.findChar('\n');
+                    } else if (next == '*') {
+                        loop:
+                        while (source.findChar('*')) {
+                            switch (source.next()) {
+                                case '/':
+                                    break loop;
+                                case ETX:
+                                    throw new UnexpectedCharacterException("Comment parse", "End of stream", source);
+                            }
+                        }
+                    }
+                };
+            }
+            return new JsonFuncParser(objectsKeysCanBeEncoded(), Arrays.copyOf(funcTable, funcTable.length),
+                    this.getDefaultFunc(), this.getParseKey());
+        }
+        else if (strict()) {
             return new JsonStrictParser(objectsKeysCanBeEncoded());
         } else {
             return new JsonFastParser(objectsKeysCanBeEncoded());

--- a/src/main/java/com/cloudurable/jparse/parser/event/JsonEventAbstractParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/event/JsonEventAbstractParser.java
@@ -13,10 +13,12 @@
  * limitations under the License.
  *
  */
-package com.cloudurable.jparse.parser;
+package com.cloudurable.jparse.parser.event;
 
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.parser.JsonEventParser;
+import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
 import com.cloudurable.jparse.source.CharSource;
 import com.cloudurable.jparse.source.support.UnexpectedCharacterException;
 import com.cloudurable.jparse.token.Token;
@@ -25,7 +27,7 @@ import com.cloudurable.jparse.token.TokenTypes;
 
 import java.util.List;
 
-public abstract class JsonEventAbstractParser implements JsonEventParser, JsonIndexOverlayParser{
+public abstract class JsonEventAbstractParser implements JsonEventParser, JsonIndexOverlayParser {
 
     private final TokenEventListener tokenEventListener;
     private TokenList tokenList;
@@ -67,19 +69,19 @@ public abstract class JsonEventAbstractParser implements JsonEventParser, JsonIn
             TokenEventListener listener;
             switch (tokenId) {
                 case TokenTypes.OBJECT_TOKEN:
-                    listener = new JsonEventStrictParser.ComplexListener(TokenTypes.OBJECT_TOKEN);
+                    listener = new ComplexListener(TokenTypes.OBJECT_TOKEN);
                     break;
                 case TokenTypes.ARRAY_TOKEN:
-                    listener = new JsonEventStrictParser.ComplexListener(TokenTypes.ARRAY_TOKEN);
+                    listener = new ComplexListener(TokenTypes.ARRAY_TOKEN);
                     break;
                 case TokenTypes.ARRAY_ITEM_TOKEN:
                     listener = arrayItemListener;
                     break;
                 case TokenTypes.ATTRIBUTE_KEY_TOKEN:
-                    listener = new JsonEventStrictParser.ComplexListener(TokenTypes.ATTRIBUTE_KEY_TOKEN);
+                    listener = new ComplexListener(TokenTypes.ATTRIBUTE_KEY_TOKEN);
                     break;
                 case TokenTypes.ATTRIBUTE_VALUE_TOKEN:
-                    listener = new JsonEventStrictParser.ComplexListener(TokenTypes.ATTRIBUTE_VALUE_TOKEN);
+                    listener = new ComplexListener(TokenTypes.ATTRIBUTE_VALUE_TOKEN);
                     break;
                 case TokenTypes.STRING_TOKEN:
                     listener = stringListener;

--- a/src/main/java/com/cloudurable/jparse/parser/functable/JsonFuncParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/functable/JsonFuncParser.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2013-2023 Richard M. Hightower
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.cloudurable.jparse.parser.functable;
+
+import com.cloudurable.jparse.node.RootNode;
+import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
+import com.cloudurable.jparse.source.CharSource;
+import com.cloudurable.jparse.source.support.UnexpectedCharacterException;
+import com.cloudurable.jparse.token.Token;
+import com.cloudurable.jparse.token.TokenTypes;
+
+import java.util.List;
+
+public class JsonFuncParser implements JsonIndexOverlayParser {
+
+    private final boolean objectsKeysCanBeEncoded;
+
+    private final ParseFunction[] funcTable;
+    private final ParsePartFunction parseKey;
+    private final ParseFunction defaultFunc;
+
+
+    public JsonFuncParser(final boolean objectsKeysCanBeEncoded, final ParseFunction[] funcTable,
+                          final ParseFunction defaultFunc, final ParsePartFunction parseKey) {
+
+        this.objectsKeysCanBeEncoded = objectsKeysCanBeEncoded;
+        this.funcTable = funcTable;
+        this.defaultFunc = defaultFunc == null ? JsonParserFunctions.defaultFunc : defaultFunc;
+
+        if (parseKey == null) {
+            if (objectsKeysCanBeEncoded) {
+                this.parseKey = JsonParserFunctions::parseKeyWithEncode;
+            } else {
+                this.parseKey = JsonParserFunctions::parseKeyNoEncode;
+            }
+        } else {
+            this.parseKey = parseKey;
+        }
+
+        funcTable[OBJECT_START_TOKEN] = this::parseObject;
+        funcTable[ARRAY_START_TOKEN] = this::parseArray;
+
+    }
+
+    @Override
+    public List<Token> scan(final CharSource source) {
+         return scan(source, new TokenList());
+    }
+
+    @Override
+    public RootNode parse(CharSource source) {
+        return new RootNode((TokenList) scan(source), source, objectsKeysCanBeEncoded);
+    }
+
+    private List<Token> scan(final CharSource source, TokenList tokens) {
+        int ch = source.nextSkipWhiteSpace();
+        doParse(source, tokens, ch);
+        return tokens;
+    }
+
+    private void doParse(final CharSource source, final TokenList tokens, final int ch) {
+        if (ch < 256) {
+            funcTable[ch].parse(source, tokens);
+        } else {
+            defaultFunc.parse(source, tokens);
+        }
+    }
+
+    public  void parseArray(final CharSource source, final TokenList tokens) {
+        final int startSourceIndex = source.getIndex();
+        final int tokenListIndex = tokens.getIndex();
+        tokens.placeHolder();
+
+        boolean done = false;
+        while (!done) {
+            done = parseArrayItem(source, tokens);
+
+        }
+        final Token arrayToken = new Token(startSourceIndex, source.getIndex(), TokenTypes.ARRAY_TOKEN);
+        tokens.set(tokenListIndex, arrayToken);
+    }
+
+    public  boolean parseArrayItem(CharSource source, TokenList tokens) {
+        char ch = (char) source.nextSkipWhiteSpace();
+
+        forLoop:
+        for (; ch != ETX; ch = (char) source.nextSkipWhiteSpace()) {
+
+            switch (ch) {
+
+                case ARRAY_END_TOKEN:
+                    source.next();
+                    return true;
+
+                case ARRAY_SEP:
+                    source.next();
+                    return false;
+
+                default:
+                   doParse(source, tokens, ch);
+                   break forLoop;
+            }
+        }
+
+        if (source.getCurrentChar() == ARRAY_END_TOKEN) {
+            source.next();
+            return true;
+        }
+        return false;
+    }
+
+
+    public  boolean parseValue(final CharSource source, TokenList tokens) {
+        int ch = source.nextSkipWhiteSpace();
+        final int startIndex = source.getIndex();
+        final int tokenListIndex = tokens.getIndex();
+        tokens.placeHolder();
+
+        doParse(source, tokens, ch);
+
+        ch = source.skipWhiteSpace();
+
+        switch (ch) {
+            case OBJECT_END_TOKEN:
+                if (source.getIndex() == tokenListIndex) {
+                    throw new UnexpectedCharacterException("Parsing Value", "Key separator before value", source);
+                }
+                tokens.set(tokenListIndex, new Token(startIndex, source.getIndex(), TokenTypes.ATTRIBUTE_VALUE_TOKEN));
+                return true;
+            case OBJECT_ATTRIBUTE_SEP:
+                if (source.getIndex() == tokenListIndex) {
+                    throw new UnexpectedCharacterException("Parsing Value", "Key separator before value", source);
+                }
+                tokens.set(tokenListIndex, new Token(startIndex, source.getIndex(), TokenTypes.ATTRIBUTE_VALUE_TOKEN));
+                return false;
+
+            default:
+                throw new UnexpectedCharacterException("Parsing Value", "Unexpected character", source, source.getCurrentChar());
+
+        }
+
+    }
+
+
+    public  void  parseObject(final CharSource source, TokenList tokens) {
+        final int startSourceIndex = source.getIndex();
+        final int tokenListIndex = tokens.getIndex();
+        tokens.placeHolder();
+
+        boolean done = false;
+        while (!done) {
+            done = parseKey.parse(source, tokens);
+            if (!done)
+              done = parseValue(source, tokens);
+        }
+        source.next();
+        tokens.set(tokenListIndex, new Token(startSourceIndex, source.getIndex(), TokenTypes.OBJECT_TOKEN));
+    }
+
+
+}

--- a/src/main/java/com/cloudurable/jparse/parser/functable/JsonParserFunctions.java
+++ b/src/main/java/com/cloudurable/jparse/parser/functable/JsonParserFunctions.java
@@ -1,0 +1,175 @@
+package com.cloudurable.jparse.parser.functable;
+
+import com.cloudurable.jparse.node.support.ParseConstants;
+import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.source.CharSource;
+import com.cloudurable.jparse.source.support.UnexpectedCharacterException;
+import com.cloudurable.jparse.token.Token;
+import com.cloudurable.jparse.token.TokenTypes;
+
+public class JsonParserFunctions {
+
+
+    public static ParseFunction defaultFunc = (source, tokens) -> {
+        throw new UnexpectedCharacterException("Scanning JSON", "Unexpected character", source);
+    };
+
+    public static void parseFalse(CharSource source, TokenList tokens) {
+        int start = source.getIndex();
+        int end = source.findFalseEnd();
+        tokens.add(new Token(start, end, TokenTypes.BOOLEAN_TOKEN));
+    }
+
+    public static void parseTrue(CharSource source, TokenList tokens) {
+        int start = source.getIndex();
+        int end = source.findTrueEnd();
+        tokens.add(new Token(start, end, TokenTypes.BOOLEAN_TOKEN));
+    }
+
+    public static void parseNull(CharSource source, TokenList tokens) {
+        int start = source.getIndex();
+        int end = source.findNullEnd();
+        tokens.add(new Token(start, end, TokenTypes.NULL_TOKEN));
+    }
+
+    public static void parseNumber(final CharSource source, TokenList tokens) {
+        final int startIndex = source.getIndex();
+        final var numberParse = source.findEndOfNumberFast();
+        tokens.add(new Token(startIndex, numberParse.endIndex(), numberParse.wasFloat() ? TokenTypes.FLOAT_TOKEN : TokenTypes.INT_TOKEN));
+    }
+
+    public static boolean parseKeyNoQuote(final CharSource source, final TokenList tokens) {
+
+        int ch = source.nextSkipWhiteSpace();
+        final int startIndex = source.getIndex() - 1;
+        final int tokenListIndex = tokens.getIndex();
+        tokens.placeHolder();
+        boolean found = false;
+
+        switch (ch) {
+
+            case ParseConstants.STRING_START_TOKEN:
+                final int strStartIndex = startIndex + 1;
+                final int strEndIndex = source.findEndOfEncodedString();
+                tokens.add(new Token(strStartIndex + 1, strEndIndex, TokenTypes.STRING_TOKEN));
+                found = true;
+                break;
+
+            case ParseConstants.OBJECT_END_TOKEN:
+                tokens.undoPlaceholder();
+                return true;
+
+            default:
+                if(Character.isAlphabetic(ch)) {
+                    final int start =  source.getIndex();
+                    final int end = source.findAttributeEnd();
+                    tokens.add(new Token(start, end, TokenTypes.STRING_TOKEN));
+                    found = true;
+                } else {
+                    throw new UnexpectedCharacterException("Parsing key", "Unexpected character found", source);
+                }
+        }
+
+
+
+        boolean done = source.findObjectEndOrAttributeSep();
+
+        if (!done && found) {
+            tokens.set(tokenListIndex, new Token(startIndex + 1, source.getIndex(), TokenTypes.ATTRIBUTE_KEY_TOKEN));
+        } else if (found && done) {
+
+            throw new UnexpectedCharacterException("Parsing key", "Not found", source);
+
+        }
+
+        return done;
+    }
+
+    public static boolean parseKeyWithEncode(final CharSource source, final TokenList tokens) {
+
+        int ch = source.nextSkipWhiteSpace();
+        final int startIndex = source.getIndex() - 1;
+        final int tokenListIndex = tokens.getIndex();
+        tokens.placeHolder();
+        boolean found = false;
+
+        switch (ch) {
+
+            case ParseConstants.STRING_START_TOKEN:
+                final int strStartIndex = startIndex + 1;
+                final int strEndIndex = source.findEndOfEncodedString();
+                tokens.add(new Token(strStartIndex + 1, strEndIndex, TokenTypes.STRING_TOKEN));
+                found = true;
+                break;
+
+            case ParseConstants.OBJECT_END_TOKEN:
+                tokens.undoPlaceholder();
+                return true;
+
+            default:
+                throw new UnexpectedCharacterException("Parsing key", "Unexpected character found", source);
+        }
+
+
+
+            boolean done = source.findObjectEndOrAttributeSep();
+
+            if (!done && found) {
+                tokens.set(tokenListIndex, new Token(startIndex + 1, source.getIndex(), TokenTypes.ATTRIBUTE_KEY_TOKEN));
+            } else if (found && done) {
+
+                throw new UnexpectedCharacterException("Parsing key", "Not found", source);
+
+            }
+
+            return done;
+
+    }
+
+    public static boolean parseKeyNoEncode(final CharSource source, final TokenList tokens) {
+
+        int ch = source.nextSkipWhiteSpace();
+        final int startIndex = source.getIndex() - 1;
+        final int tokenListIndex = tokens.getIndex();
+        tokens.placeHolder();
+        boolean found = false;
+
+        switch (ch) {
+
+            case ParseConstants.STRING_START_TOKEN:
+                final int strStartIndex = startIndex + 1;
+                final int strEndIndex = source.findEndString();
+                tokens.add(new Token(strStartIndex + 1, strEndIndex, TokenTypes.STRING_TOKEN));
+                found = true;
+                break;
+
+            case ParseConstants.OBJECT_END_TOKEN:
+                tokens.undoPlaceholder();
+                return true;
+
+            default:
+                throw new UnexpectedCharacterException("Parsing key", "Unexpected character found", source);
+        }
+
+
+
+        boolean done = source.findObjectEndOrAttributeSep();
+
+        if (!done && found) {
+            tokens.set(tokenListIndex, new Token(startIndex + 1, source.getIndex(), TokenTypes.ATTRIBUTE_KEY_TOKEN));
+        } else if (found && done) {
+
+            throw new UnexpectedCharacterException("Parsing key", "Not found", source);
+
+        }
+
+        return done;
+
+    }
+
+    public static void parseString(final CharSource source, TokenList tokens) {
+        final int startIndex = source.getIndex();
+        final int endIndex = source.findEndOfEncodedStringFast();
+        tokens.add(new Token(startIndex + 1, endIndex, TokenTypes.STRING_TOKEN));
+    }
+}

--- a/src/main/java/com/cloudurable/jparse/parser/functable/ParseFunction.java
+++ b/src/main/java/com/cloudurable/jparse/parser/functable/ParseFunction.java
@@ -1,0 +1,9 @@
+package com.cloudurable.jparse.parser.functable;
+
+import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.source.CharSource;
+
+public interface ParseFunction {
+
+   void parse(CharSource source, TokenList tokens);
+}

--- a/src/main/java/com/cloudurable/jparse/parser/functable/ParsePartFunction.java
+++ b/src/main/java/com/cloudurable/jparse/parser/functable/ParsePartFunction.java
@@ -1,0 +1,9 @@
+package com.cloudurable.jparse.parser.functable;
+
+import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.source.CharSource;
+
+public interface ParsePartFunction {
+
+    boolean parse(CharSource source, TokenList tokens);
+}

--- a/src/main/java/com/cloudurable/jparse/parser/indexoverlay/JsonFastParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/indexoverlay/JsonFastParser.java
@@ -13,10 +13,11 @@
  * limitations under the License.
  *
  */
-package com.cloudurable.jparse.parser;
+package com.cloudurable.jparse.parser.indexoverlay;
 
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
 import com.cloudurable.jparse.source.CharSource;
 import com.cloudurable.jparse.source.support.UnexpectedCharacterException;
 import com.cloudurable.jparse.token.Token;
@@ -172,11 +173,7 @@ public class JsonFastParser implements JsonIndexOverlayParser {
                 case MINUS:
                 case PLUS:
                     parseNumber(source, tokens);
-                    if (source.getCurrentChar() == ARRAY_END_TOKEN ) {
-                            source.next();
-                            return true;
-                    }
-                    break;
+                    break forLoop;
 
                 case ARRAY_END_TOKEN:
                     source.next();

--- a/src/main/java/com/cloudurable/jparse/parser/indexoverlay/JsonStrictParser.java
+++ b/src/main/java/com/cloudurable/jparse/parser/indexoverlay/JsonStrictParser.java
@@ -13,10 +13,11 @@
  * limitations under the License.
  *
  */
-package com.cloudurable.jparse.parser;
+package com.cloudurable.jparse.parser.indexoverlay;
 
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.support.TokenList;
+import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
 import com.cloudurable.jparse.source.CharSource;
 import com.cloudurable.jparse.source.support.UnexpectedCharacterException;
 import com.cloudurable.jparse.token.Token;

--- a/src/main/java/com/cloudurable/jparse/source/CharArrayCharSource.java
+++ b/src/main/java/com/cloudurable/jparse/source/CharArrayCharSource.java
@@ -549,6 +549,44 @@ public class CharArrayCharSource implements CharSource, ParseConstants {
     }
 
     @Override
+    public int findAttributeEnd() {
+        int index = this.index;
+        final var data = this.data;
+        final var length = this.data.length;
+
+        loop:
+        for (; index < length; index++){
+            char ch = data[index];
+            switch (ch) {
+                case NEW_LINE_WS:
+                case CARRIAGE_RETURN_WS:
+                case TAB_WS:
+                case SPACE_WS:
+                case ATTRIBUTE_SEP:
+                   this.index = index;
+                   break loop;
+            }
+        }
+
+        return index;
+    }
+
+    @Override
+    public boolean findChar(char c) {
+        int index = this.index;
+        final var data = this.data;
+        final var length = this.data.length;
+
+        for (; index < length; index++){
+            if (data[index]==c){
+                this.index = index;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public int findEndString() {
 
         int i = ++index;

--- a/src/main/java/com/cloudurable/jparse/source/CharArrayOffsetCharSource.java
+++ b/src/main/java/com/cloudurable/jparse/source/CharArrayOffsetCharSource.java
@@ -103,6 +103,44 @@ public class CharArrayOffsetCharSource implements CharSource, ParseConstants {
     }
 
     @Override
+    public int findAttributeEnd() {
+        int index = this.index;
+        final var data = this.data;
+        final var end = this.sourceEndIndex;
+
+        loop:
+        for (; index < end; index++){
+            char ch = data[index];
+            switch (ch) {
+                case NEW_LINE_WS:
+                case CARRIAGE_RETURN_WS:
+                case TAB_WS:
+                case SPACE_WS:
+                case ATTRIBUTE_SEP:
+                    this.index = index;
+                    break loop;
+            }
+        }
+
+        return index;
+    }
+
+    @Override
+    public boolean findChar(char c) {
+        int index = this.index;
+        final var data = this.data;
+        final var end = sourceEndIndex;
+
+        for (; index < end; index++){
+            if (data[index]==c){
+                this.index = index;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public void checkForJunk() {
         int index = this.index;
         final var data = this.data;

--- a/src/main/java/com/cloudurable/jparse/source/CharSource.java
+++ b/src/main/java/com/cloudurable/jparse/source/CharSource.java
@@ -90,4 +90,8 @@ public interface CharSource {
     NumberParseResult findEndOfNumberFast();
 
     int findEndOfEncodedStringFast();
+
+    boolean findChar(char c);
+
+    int findAttributeEnd();
 }

--- a/src/test/java/com/cloudurable/jparse/EqualityTest.java
+++ b/src/test/java/com/cloudurable/jparse/EqualityTest.java
@@ -20,7 +20,6 @@ import com.cloudurable.jparse.node.NodeType;
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.node.StringNode;
 import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
-import com.cloudurable.jparse.parser.JsonStrictParser;
 import com.cloudurable.jparse.source.Sources;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/cloudurable/jparse/JsonParserFuncTableNoQuoteKeyTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonParserFuncTableNoQuoteKeyTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2013-2023 Richard M. Hightower
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.cloudurable.jparse;
+
+import com.cloudurable.jparse.node.ArrayNode;
+import com.cloudurable.jparse.node.RootNode;
+import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
+import org.junit.jupiter.api.Test;
+
+import static com.cloudurable.jparse.node.JsonTestUtils.asInt;
+import static com.cloudurable.jparse.node.JsonTestUtils.showTokens;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonParserFuncTableNoQuoteKeyTest extends JsonParserTest {
+
+    @Override
+    public  JsonIndexOverlayParser jsonParser() {
+        final var parser = Json.builder().setAllowComments(true)
+                .setSupportNoQuoteKeys(true).build();
+
+        System.out.println("             " + parser.getClass().getName());
+        return parser;
+    }
+
+
+    @Test
+    public void testComplexMapNoQuoteKey() {
+        //................012345678901234567890123
+        final var json = "{abc:2,'def':7, xyz :[1,2,3]}";
+        final RootNode root = jsonParser().parse(Json.niceJson(json));
+
+        final var jsonObject = root.getMap();
+        assertEquals(2, asInt(jsonObject, "abc"));
+        assertEquals(7, asInt(jsonObject, "def"));
+
+        ArrayNode arrayNode = root.asObject().getArrayNode("xyz");
+        showTokens(arrayNode.tokens());
+
+        assertEquals(1L,arrayNode.getNodeAt(0).asScalar().longValue());
+        //assertEquals(1L, );
+    }
+
+
+    @Test
+    public void testDoubleArrayWithComment() {
+        //................012345678901234567890123
+        final var json = "[1, 1.1, 1.2, 1.3, " +
+                "\n#hi noah \n1e+9, 1e9, 1e-9]";
+        final double[] array = {1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9};
+        double[] readDoubles = toArrayNode(niceJson(json)).getDoubleArray();
+        assertArrayEquals(array, readDoubles);
+    }
+
+    @Test
+    public void testDoubleArrayWithSlashSlash() {
+        //................012345678901234567890123
+        final var json = "[1, 1.1, 1.2, 1.3, " +
+                "\n//hi noah \n1e+9, 1e9, 1e-9]";
+        final double[] array = {1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9};
+        double[] readDoubles = toArrayNode(niceJson(json)).getDoubleArray();
+        assertArrayEquals(array, readDoubles);
+    }
+
+    @Test
+    public void testDoubleArrayWithSlashStar() {
+        //................012345678901234567890123
+        final var json = "[1, 1.1, 1.2, 1.3, " +
+                "\n/*hi noah \n\n\n*/1e+9, 1e9, 1e-9]";
+        final double[] array = {1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9};
+        double[] readDoubles = toArrayNode(niceJson(json)).getDoubleArray();
+        assertArrayEquals(array, readDoubles);
+    }
+
+    @Test
+    public void testComplexMap2() {
+        //................012345678901234567890123
+        final var json = "{'1':2,'2':7,'3':[1,2,3]}";
+        final RootNode root = jsonParser().parse(Json.niceJson(json));
+
+        showTokens(root.tokens());
+
+        final var jsonObject = root.getMap();
+        assertEquals(2, asInt(jsonObject, "1"));
+        assertEquals(7, asInt(jsonObject, "2"));
+
+        ArrayNode arrayNode = root.asObject().getArrayNode("3");
+        showTokens(arrayNode.tokens());
+
+        assertEquals(1L,arrayNode.getNodeAt(0).asScalar().longValue());
+
+        //assertEquals(List.of(1L, 2L, 3L), asArray(jsonObject, "3").stream().map(n->n.asScalar().longValue()).collect(Collectors.toList()));
+
+    }
+}

--- a/src/test/java/com/cloudurable/jparse/JsonParserFuncTableTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonParserFuncTableTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2013-2023 Richard M. Hightower
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.cloudurable.jparse;
+
+import com.cloudurable.jparse.node.ArrayNode;
+import com.cloudurable.jparse.node.RootNode;
+import com.cloudurable.jparse.parser.functable.JsonFuncParser;
+import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
+import org.junit.jupiter.api.Test;
+
+import static com.cloudurable.jparse.node.JsonTestUtils.asInt;
+import static com.cloudurable.jparse.node.JsonTestUtils.showTokens;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonParserFuncTableTest extends JsonParserTest {
+
+    @Override
+    public  JsonIndexOverlayParser jsonParser() {
+        final var parser = Json.builder().setAllowComments(true).build();
+
+        System.out.println("             " + parser.getClass().getName());
+        return parser;
+    }
+
+
+
+    @Test
+    public void testDoubleArrayWithComment() {
+        //................012345678901234567890123
+        final var json = "[1, 1.1, 1.2, 1.3, " +
+                "\n#hi noah \n1e+9, 1e9, 1e-9]";
+        final double[] array = {1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9};
+        double[] readDoubles = toArrayNode(niceJson(json)).getDoubleArray();
+        assertArrayEquals(array, readDoubles);
+    }
+
+    @Test
+    public void testDoubleArrayWithSlashSlash() {
+        //................012345678901234567890123
+        final var json = "[1, 1.1, 1.2, 1.3, " +
+                "\n//hi noah \n1e+9, 1e9, 1e-9]";
+        final double[] array = {1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9};
+        double[] readDoubles = toArrayNode(niceJson(json)).getDoubleArray();
+        assertArrayEquals(array, readDoubles);
+    }
+
+    @Test
+    public void testDoubleArrayWithSlashStar() {
+        //................012345678901234567890123
+        final var json = "[1, 1.1, 1.2, 1.3, " +
+                "\n/*hi noah \n\n\n*/1e+9, 1e9, 1e-9]";
+        final double[] array = {1, 1.1, 1.2, 1.3, 1e+9, 1e9, 1e-9};
+        double[] readDoubles = toArrayNode(niceJson(json)).getDoubleArray();
+        assertArrayEquals(array, readDoubles);
+    }
+
+    @Test
+    public void testComplexMap2() {
+        //................012345678901234567890123
+        final var json = "{'1':2,'2':7,'3':[1,2,3]}";
+        final RootNode root = jsonParser().parse(Json.niceJson(json));
+
+        showTokens(root.tokens());
+
+        final var jsonObject = root.getMap();
+        assertEquals(2, asInt(jsonObject, "1"));
+        assertEquals(7, asInt(jsonObject, "2"));
+
+        ArrayNode arrayNode = root.asObject().getArrayNode("3");
+        showTokens(arrayNode.tokens());
+
+        assertEquals(1L,arrayNode.getNodeAt(0).asScalar().longValue());
+
+        //assertEquals(List.of(1L, 2L, 3L), asArray(jsonObject, "3").stream().map(n->n.asScalar().longValue()).collect(Collectors.toList()));
+
+    }
+}

--- a/src/test/java/com/cloudurable/jparse/JsonParserTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonParserTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;

--- a/src/test/java/com/cloudurable/jparse/JsonScannerFuncTest.java
+++ b/src/test/java/com/cloudurable/jparse/JsonScannerFuncTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2013-2023 Richard M. Hightower
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.cloudurable.jparse;
+
+import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
+
+public class JsonScannerFuncTest extends JsonScannerTest{
+    @Override
+    public JsonIndexOverlayParser jsonParser() {
+        return Json.builder().setAllowComments(true).build();
+    }
+}

--- a/src/test/java/com/cloudurable/jparse/ObjectSerializerTest.java
+++ b/src/test/java/com/cloudurable/jparse/ObjectSerializerTest.java
@@ -18,7 +18,6 @@ package com.cloudurable.jparse;
 import com.cloudurable.jparse.node.ArrayNode;
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
-import com.cloudurable.jparse.parser.JsonStrictParser;
 import com.cloudurable.jparse.source.Sources;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/cloudurable/jparse/TestKeyLookUp.java
+++ b/src/test/java/com/cloudurable/jparse/TestKeyLookUp.java
@@ -18,7 +18,6 @@ package com.cloudurable.jparse;
 import com.cloudurable.jparse.node.ObjectNode;
 import com.cloudurable.jparse.node.RootNode;
 import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
-import com.cloudurable.jparse.parser.JsonStrictParser;
 import com.cloudurable.jparse.source.Sources;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/cloudurable/jparse/node/support/ElementUtilTest.java
+++ b/src/test/java/com/cloudurable/jparse/node/support/ElementUtilTest.java
@@ -16,7 +16,6 @@
 package com.cloudurable.jparse.node.support;
 
 import com.cloudurable.jparse.Json;
-import com.cloudurable.jparse.parser.JsonStrictParser;
 import com.cloudurable.jparse.parser.JsonIndexOverlayParser;
 import com.cloudurable.jparse.node.NodeType;
 import com.cloudurable.jparse.node.RootNode;


### PR DESCRIPTION
#31 


```
3/12/2023

Benchmark                          Mode  Cnt        Score   Error  Units
BenchMark.jParseFuncFloatArray    thrpt    2   922788.015          ops/s
BenchMark.jParseFastFloatArray    thrpt    2   920226.057          ops/s
BenchMark.jacksonLongArray        thrpt    2  1183254.929          ops/s
BenchMark.jsonIteratorLongArray   thrpt    2   651889.526          ops/s


BenchMark.jParseFastLongArray     thrpt    2  1636702.624          ops/s
BenchMark.jParseFuncLongArray     thrpt    2  1578814.531          ops/s
BenchMark.jsonIteratorFloatArray  thrpt    2   587694.388          ops/s
BenchMark.jacksonFloatArray       thrpt    2   482954.920          ops/s



Benchmark                          Mode  Cnt       Score   Error  Units
BenchMark.readGlossaryJParseFunc  thrpt    2  998351.523          ops/s
BenchMark.readGlossaryJParseFast  thrpt    2  998141.054          ops/s
BenchMark.readGlossaryJsonIter    thrpt    2  538367.458          ops/s
BenchMark.readGlossaryJackson     thrpt    2  485629.182          ops/s

BenchMark.readWebJSONJParseFast   thrpt    2  228120.219          ops/s
BenchMark.readWebJSONJParseFunc   thrpt    2  216451.525          ops/s
BenchMark.readWebJsonJsonIter     thrpt    2  121688.550          ops/s
BenchMark.readWebJsonJackson      thrpt    2  114764.498          ops/s



3/12/2023

Benchmark                          Mode  Cnt       Score   Error  Units
BenchMark.readGlossaryJParseFast  thrpt    2  989839.209          ops/s
BenchMark.readGlossaryJParseFunc  thrpt    2  894503.096          ops/s
BenchMark.readGlossaryJsonIter    thrpt    2  536260.679          ops/s
BenchMark.readGlossaryJackson     thrpt    2  479379.317          ops/s


BenchMark.readWebJSONJParseFast   thrpt    2  228223.929          ops/s
BenchMark.readWebJSONJParseFunc   thrpt    2  208328.302          ops/s
BenchMark.readWebJsonJsonIter     thrpt    2  125439.211          ops/s
BenchMark.readWebJsonJackson      thrpt    2  113809.616          ops/s

Run 2

Benchmark                          Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryJParseFast  thrpt    2  1009227.512          ops/s
BenchMark.readGlossaryJParseFunc  thrpt    2   897270.959          ops/s
BenchMark.readGlossaryJackson     thrpt    2   473973.306          ops/s
BenchMark.readGlossaryJsonIter    thrpt    2   531562.520          ops/s

BenchMark.readWebJSONJParseFast   thrpt    2   219650.387          ops/s
BenchMark.readWebJSONJParseFunc   thrpt    2   207987.967          ops/s
BenchMark.readWebJsonJackson      thrpt    2   113190.832          ops/s
BenchMark.readWebJsonJsonIter     thrpt    2   119726.889          ops/s

Run 3

Benchmark                          Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryJParseFast  thrpt    2  1018530.780          ops/s
BenchMark.readGlossaryJParseFunc  thrpt    2   915243.574          ops/s
BenchMark.readGlossaryJackson     thrpt    2   478456.793          ops/s
BenchMark.readGlossaryJsonIter    thrpt    2   540220.144          ops/s

BenchMark.readWebJSONJParseFast   thrpt    2   228313.353          ops/s
BenchMark.readWebJSONJParseFunc   thrpt    2   211720.212          ops/s
BenchMark.readWebJsonJackson      thrpt    2   111300.196          ops/s
BenchMark.readWebJsonJsonIter     thrpt    2   116478.267          ops/s

Run 4
Benchmark                          Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryJParseFast  thrpt    2  1032326.554          ops/s
BenchMark.readGlossaryJParseFunc  thrpt    2   916692.170          ops/s
BenchMark.readGlossaryJackson     thrpt    2   468141.489          ops/s
BenchMark.readGlossaryJsonIter    thrpt    2   536985.265          ops/s

BenchMark.readWebJSONJParseFast   thrpt    2   225614.274          ops/s
BenchMark.readWebJSONJParseFunc   thrpt    2   207216.668          ops/s
BenchMark.readWebJsonJackson      thrpt    2   113831.641          ops/s
BenchMark.readWebJsonJsonIter     thrpt    2   122361.191          ops/s

Run 5 (no quote key)
Benchmark                          Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryJParseFast  thrpt    2  1002118.697          ops/s
BenchMark.readGlossaryJParseFunc  thrpt    2   863111.207          ops/s
BenchMark.readWebJSONJParseFast   thrpt    2   218926.404          ops/s
BenchMark.readWebJSONJParseFunc   thrpt    2   210835.039          ops/s

Run 6 no quote key
Benchmark                          Mode  Cnt        Score   Error  Units
BenchMark.readGlossaryJParseFast  thrpt    2  1004868.750          ops/s
BenchMark.readGlossaryJParseFunc  thrpt    2   883662.161          ops/s
BenchMark.readWebJSONJParseFast   thrpt    2   224225.332          ops/s
BenchMark.readWebJSONJParseFunc   thrpt    2   211388.867          ops/s


Run 7

Benchmark                          Mode  Cnt        Score   Error  Units
BenchMark.jParseFastFloatArray    thrpt    2   852977.777          ops/s
BenchMark.jParseFuncFloatArray    thrpt    2   843032.008          ops/s

BenchMark.jParseFastLongArray     thrpt    2  1391471.828          ops/s
BenchMark.jParseFuncLongArray     thrpt    2  1168788.545          ops/s

BenchMark.readGlossaryJParseFast  thrpt    2  1053185.841          ops/s
BenchMark.readGlossaryJParseFunc  thrpt    2   890139.267          ops/s

```